### PR TITLE
feat: Add a shortcuts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import { AnimatePresence } from 'framer-motion';
 import Palette from './components/Palette';
 import Studio from './components/Studio';
 import RecordingBar from './components/RecordingBar';
-import useKeyboardShortcut from './lib/hooks/useKeyboardShortcut';
+import { APP_SHORTCUTS, matchesShortcut, isEditableTarget } from './lib/shortcut';
 import { WindowMode } from './types/types';
 
 export default function App() {
@@ -70,7 +70,24 @@ export default function App() {
     }
   };
 
-  useKeyboardShortcut({ alt: true, ctrl: true, key: 's' }, switchToPalette);
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+      for (const shortcut of APP_SHORTCUTS) {
+        if (matchesShortcut(shortcut, e)) {
+          e.preventDefault();
+          switch (shortcut.action) {
+            case 'toggle-palette':
+              switchToPalette();
+              break;
+          }
+          break;
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [switchToPalette]);
 
   useEffect(() => {
     const unsub = EventsOn('toggle-palette', switchToPalette);

--- a/frontend/src/components/Palette.tsx
+++ b/frontend/src/components/Palette.tsx
@@ -1,10 +1,38 @@
+import { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Camera, Crop, Type, EyeOff, Video, X } from 'lucide-react';
 import { Button } from './ui/button';
 import ToolButton from './ToolButton';
-import { PaletteProps } from '@/types/types';
+import { PALETTE_SHORTCUTS, matchesShortcut, isEditableTarget } from '@/lib/shortcut';
 
 export default function Palette({ onTakeScreenshot, onTakeAreaScreenshot, onSwitchToStudio, onClose, onStartRecording }: any) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+      for (const shortcut of PALETTE_SHORTCUTS) {
+        if (matchesShortcut(shortcut, e)) {
+          e.preventDefault();
+          switch (shortcut.action) {
+            case 'full-screen':
+              onTakeScreenshot();
+              break;
+            case 'select-area':
+              onTakeAreaScreenshot();
+              break;
+            case 'studio':
+              onSwitchToStudio();
+              break;
+          }
+          break;
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onTakeScreenshot, onTakeAreaScreenshot, onSwitchToStudio]);
+
+  const shortcutFor = (action: string) => PALETTE_SHORTCUTS.find(s => s.action === action)?.keys;
+
   return (
     <motion.div
       key="palette"
@@ -13,11 +41,12 @@ export default function Palette({ onTakeScreenshot, onTakeAreaScreenshot, onSwit
       exit={{ opacity: 0, scale: 0.9 }}
       className="flex items-center gap-2 p-2 rounded-2xl backdrop-blur-2xl bg-black shadow-2xl text-white"
     >
-      <ToolButton icon={<Camera size={18} />} label="Full Screen" onClick={onTakeScreenshot} />
-      <ToolButton icon={<Crop size={18} />} label="Select Area" onClick={onTakeAreaScreenshot} />
-      {/*<ToolButton icon={<Video size={18} />} label="Record" onClick={onStartRecording} />
+      <ToolButton icon={<Camera size={18} />} label="Full Screen" shortcut={shortcutFor('full-screen')} onClick={onTakeScreenshot} />
+      <ToolButton icon={<Crop size={18} />} label="Select Area" shortcut={shortcutFor('select-area')} onClick={onTakeAreaScreenshot} />
+      {/* Commented-out buttons intentionally get no shortcut.
+      <ToolButton icon={<Video size={18} />} label="Record" onClick={onStartRecording} />
       <ToolButton icon={<Type size={18} />} label="OCR Text" />
-      <ToolButton icon={<EyeOff size={18} />} label="Smart Blur" />*/}
+      <ToolButton icon={<EyeOff size={18} />} label="Smart Blur" /> */}
 
       <div className="h-6 w-[1px] bg-white/20 mx-1" />
 

--- a/frontend/src/components/ToolButton.tsx
+++ b/frontend/src/components/ToolButton.tsx
@@ -5,9 +5,10 @@ interface ToolButtonProps {
   icon: React.ReactNode;
   label: string;
   onClick?: () => void;
+  shortcut?: string;
 }
 
-export default function ToolButton({ icon, label, onClick }: ToolButtonProps) {
+export default function ToolButton({ icon, label, onClick, shortcut }: ToolButtonProps) {
   return (
     <motion.button
       whileHover={{ scale: 1.08, backgroundColor: 'rgba(255, 255, 255, 0.15)' }}
@@ -18,6 +19,7 @@ export default function ToolButton({ icon, label, onClick }: ToolButtonProps) {
       {icon}
       <span className="absolute -top-9 scale-0 group-hover:scale-100 transition-all duration-150 bg-black/80 text-[11px] px-2 py-0.5 rounded-md border border-white/10 text-white/90 whitespace-nowrap backdrop-blur-md shadow-lg pointer-events-none">
         {label}
+        {shortcut ? <span className="ml-1.5 text-white/50">{shortcut}</span> : null}
       </span>
     </motion.button>
   );

--- a/frontend/src/components/editor/Canvas.tsx
+++ b/frontend/src/components/editor/Canvas.tsx
@@ -558,6 +558,14 @@ const Canvas = forwardRef<Konva.Stage, CanvasProps>(({
             fontFamily={shape.fontFamily}
             fontStyle={shape.fontStyle}
             wrap="word"
+            onDblClick={(e) => {
+              e.cancelBubble = true;
+              onTextDoubleClick(shape);
+            }}
+            onDblTap={(e) => {
+              e.cancelBubble = true;
+              onTextDoubleClick(shape);
+            }}
             onTransform={handleTextTransform}
             onTransformEnd={handleTextTransformEnd}
             rotation={rotation}

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -13,6 +13,7 @@ import InlineTextEditor from './InlineTextEditor';
 import Canvas from './Canvas';
 import FloatingToolbar from './FloatingToolbar';
 import { SaveFileDialog, WriteFile } from '../../../wailsjs/go/main/App';
+import { EDITOR_SHORTCUTS, matchesShortcut, isEditableTarget, type EditorAction } from '@/lib/shortcut';
 
 interface ToolStyleState {
   color: string;
@@ -342,127 +343,75 @@ export default function Editor({ imageUrl, onBack }: EditorProps) {
   const clipboardRef = useRef<ShapeConfig | null>(null);
 
   useEffect(() => {
-    const isEditableTarget = (target: EventTarget | null) => {
-      if (!(target instanceof HTMLElement)) return false;
-
-    const tag = target.tagName;
-    return (
-      tag === 'INPUT' ||
-      tag === 'TEXTAREA' ||
-      tag === 'SELECT' ||
-      target.isContentEditable
-    );
-  };
-
     const handleKeyDown = (e: KeyboardEvent) => {
       if (editingTextId) return;
       if (isEditableTarget(e.target)) return;
 
-    const isCtrl = e.ctrlKey || e.metaKey;
-
-    if (e.key === 'Enter' && selectedTool === 'select' && selectedId) {
-      const shape = shapes.find((s) => s.id === selectedId);
-      if (shape && (shape.type === 'text' || shape.type === 'number')) {
-        e.preventDefault();
-        beginEditing(shape);
-        return;
-      }
-    }
-
-    if ((e.key === 'Delete' || e.key === 'Backspace') && selectedId) {
-      e.preventDefault();
-      deleteShape(selectedId);
-      return;
-    }
-
-    if (isCtrl && e.code === 'KeyZ' && !e.shiftKey) {
-      e.preventDefault();
-      handleUndo();
-      return;
-    }
-
-    if (
-      isCtrl &&
-      (e.code === 'KeyY' || (e.code === 'KeyZ' && e.shiftKey))
-    ) {
-      e.preventDefault();
-      handleRedo();
-      return;
-    }
-
-    if (isCtrl && e.code === 'KeyS') {
-      e.preventDefault();
-      exportImage();
-      return;
-    }
-
-    if (isCtrl && e.code === 'KeyC' && selectedId) {
-      e.preventDefault();
-
-      const shape = shapes.find((s) => s.id === selectedId);
-      if (shape) {
-        clipboardRef.current = { ...shape };
-      }
-
-      return;
-    }
-
-    if (isCtrl && e.code === 'KeyV' && clipboardRef.current) {
-      e.preventDefault();
-
-      const newId =
-        Date.now().toString(36) +
-        Math.random().toString(36).substring(2, 7);
-
-      const pastedShape: ShapeConfig = {
-        ...clipboardRef.current,
-        id: newId,
-        x: (clipboardRef.current.x ?? 0) + 20,
-        y: (clipboardRef.current.y ?? 0) + 20,
+      const runAction = (action: EditorAction): boolean => {
+        switch (action) {
+          case 'edit-text': {
+            if (selectedTool !== 'select' || !selectedId) return false;
+            const shape = shapes.find(s => s.id === selectedId);
+            if (!shape || (shape.type !== 'text' && shape.type !== 'number')) return false;
+            beginEditing(shape);
+            return true;
+          }
+          case 'delete':
+            if (!selectedId) return false;
+            deleteShape(selectedId);
+            return true;
+          case 'undo':
+            handleUndo();
+            return true;
+          case 'redo':
+            handleRedo();
+            return true;
+          case 'export':
+            exportImage();
+            return true;
+          case 'copy': {
+            if (!selectedId) return false;
+            const shape = shapes.find(s => s.id === selectedId);
+            if (shape) clipboardRef.current = { ...shape };
+            return true;
+          }
+          case 'paste': {
+            if (!clipboardRef.current) return false;
+            const newId = Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+            const pastedShape: ShapeConfig = {
+              ...clipboardRef.current,
+              id: newId,
+              x: (clipboardRef.current.x || 0) + 20,
+              y: (clipboardRef.current.y || 0) + 20,
+            };
+            addShape(pastedShape, true);
+            setSelectedTool('select');
+            return true;
+          }
+          case 'duplicate': {
+            if (!selectedId) return false;
+            const shape = shapes.find(s => s.id === selectedId);
+            if (shape) handleDuplicate(shape);
+            return true;
+          }
+          case 'deselect':
+            setSelectedId(null);
+            return true;
+        }
+        return false;
       };
 
-      addShape(pastedShape, true);
-      setSelectedTool('select');
-      return;
-    }
-
-    if (isCtrl && e.code === 'KeyD' && selectedId) {
-      e.preventDefault();
-
-      const shape = shapes.find((s) => s.id === selectedId);
-      if (shape) {
-        handleDuplicate(shape);
+      for (const shortcut of EDITOR_SHORTCUTS) {
+        if (matchesShortcut(shortcut, e) && runAction(shortcut.action)) {
+          e.preventDefault();
+          break;
+        }
       }
-
-      return;
-    }
-
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      setSelectedId(null);
-      return;
-    }
-  };
+    };
 
     window.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [
-    selectedId,
-    selectedTool,
-    shapes,
-    editingTextId,
-    deleteShape,
-    addShape,
-    handleDuplicate,
-    handleUndo,
-    handleRedo,
-    beginEditing,
-    setSelectedTool,
-    setSelectedId,
-  ]);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selectedId, selectedTool, shapes, editingTextId, deleteShape, addShape, handleDuplicate, handleUndo, handleRedo, beginEditing, setSelectedTool, setSelectedId]);
 
   return (
     <div className="w-full h-screen flex flex-col bg-black/95 backdrop-blur-3xl rounded-3xl border border-white/10 overflow-hidden text-white">
@@ -470,7 +419,7 @@ export default function Editor({ imageUrl, onBack }: EditorProps) {
         <button onClick={onBack} className="flex items-center gap-2 text-sm hover:bg-white/10 px-3 py-1 rounded-lg">
           <X size={16} /> Back
         </button>
-        <Toolbar selectedTool={selectedTool} onToolChange={handleToolChange} />
+        <Toolbar selectedTool={selectedTool} onToolChange={handleToolChange} isEditingText={!!editingTextId} />
         <div className="flex gap-2">
           <button onClick={handleUndo} className="p-2 hover:bg-white/10 rounded"><Undo2 size={16} /></button>
           <button onClick={handleRedo} className="p-2 hover:bg-white/10 rounded"><Redo2 size={16} /></button>

--- a/frontend/src/components/editor/Toolbar.tsx
+++ b/frontend/src/components/editor/Toolbar.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Crop, ArrowUpRight, Type, Hash, Pen, Square, Circle as CircleIcon, MousePointer2 } from 'lucide-react';
 import { Tool } from '@/types/types';
+import { TOOL_SHORTCUTS, matchesShortcut, isEditableTarget } from '@/lib/shortcut';
 
 interface ToolbarProps {
   selectedTool: Tool;
   onToolChange: (tool: Tool) => void;
+  isEditingText?: boolean;
 }
 
 const tools: { tool: Tool; icon: React.ElementType; label: string }[] = [
@@ -19,7 +21,26 @@ const tools: { tool: Tool; icon: React.ElementType; label: string }[] = [
   { tool: 'circle', icon: CircleIcon, label: 'Circle' },
 ];
 
-export default function Toolbar({ selectedTool, onToolChange }: ToolbarProps) {
+const shortcutFor = (tool: Tool): string | undefined =>
+  TOOL_SHORTCUTS.find(s => s.tool === tool)?.keys;
+
+export default function Toolbar({ selectedTool, onToolChange, isEditingText }: ToolbarProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditingText) return;
+      if (isEditableTarget(e.target)) return;
+      for (const shortcut of TOOL_SHORTCUTS) {
+        if (matchesShortcut(shortcut, e)) {
+          e.preventDefault();
+          onToolChange(shortcut.tool);
+          break;
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onToolChange, isEditingText]);
+
   return (
     <div className="flex gap-0.5 bg-black/40 backdrop-blur-md rounded-xl p-1 border border-white/10">
       {tools.map(({ tool, icon: Icon, label }) => (
@@ -33,7 +54,7 @@ export default function Toolbar({ selectedTool, onToolChange }: ToolbarProps) {
               ? 'text-white bg-white/20 shadow-sm'
               : 'text-white/60 hover:text-white/90'
           }`}
-          title={label}
+          title={`${label} (${shortcutFor(tool) ?? ''})`}
         >
           <Icon size={16} />
           {selectedTool === tool && (

--- a/frontend/src/lib/shortcut.ts
+++ b/frontend/src/lib/shortcut.ts
@@ -1,0 +1,267 @@
+import { Tool } from '@/types/types';
+
+export type ShortcutCategory = 'editor' | 'tool' | 'palette' | 'app';
+
+export interface ShortcutDef {
+  id: string;
+  label: string;
+  keys: string;
+  key: string;
+  alt?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+  category: ShortcutCategory;
+}
+
+export type EditorAction =
+  | 'edit-text'
+  | 'delete'
+  | 'undo'
+  | 'redo'
+  | 'export'
+  | 'copy'
+  | 'paste'
+  | 'duplicate'
+  | 'deselect';
+
+export interface EditorShortcut extends ShortcutDef {
+  category: 'editor';
+  action: EditorAction;
+}
+
+export const EDITOR_SHORTCUTS: EditorShortcut[] = [
+  {
+    id: 'editor-edit-text',
+    action: 'edit-text',
+    label: 'Edit selected text',
+    keys: 'Enter',
+    key: 'Enter',
+    category: 'editor',
+  },
+  {
+    id: 'editor-delete',
+    action: 'delete',
+    label: 'Delete selected shape',
+    keys: 'Delete',
+    key: 'Delete',
+    category: 'editor',
+  },
+  {
+    id: 'editor-delete-backspace',
+    action: 'delete',
+    label: 'Delete selected shape',
+    keys: 'Backspace',
+    key: 'Backspace',
+    category: 'editor',
+  },
+  {
+    id: 'editor-undo',
+    action: 'undo',
+    label: 'Undo',
+    keys: 'Ctrl+Z',
+    key: 'z',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-redo',
+    action: 'redo',
+    label: 'Redo',
+    keys: 'Ctrl+Shift+Z',
+    key: 'z',
+    ctrl: true,
+    shift: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-redo-alternate',
+    action: 'redo',
+    label: 'Redo (alternate)',
+    keys: 'Ctrl+Y',
+    key: 'y',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-export',
+    action: 'export',
+    label: 'Export image',
+    keys: 'Ctrl+S',
+    key: 's',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-copy',
+    action: 'copy',
+    label: 'Copy shape',
+    keys: 'Ctrl+C',
+    key: 'c',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-paste',
+    action: 'paste',
+    label: 'Paste shape',
+    keys: 'Ctrl+V',
+    key: 'v',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-duplicate',
+    action: 'duplicate',
+    label: 'Duplicate shape',
+    keys: 'Ctrl+D',
+    key: 'd',
+    ctrl: true,
+    category: 'editor',
+  },
+  {
+    id: 'editor-deselect',
+    action: 'deselect',
+    label: 'Deselect all',
+    keys: 'Escape',
+    key: 'Escape',
+    category: 'editor',
+  },
+];
+
+
+export interface ToolShortcut extends ShortcutDef {
+  category: 'tool';
+  tool: Tool;
+}
+
+export const TOOL_SHORTCUT_KEYS: Record<string, Tool> = {
+  v: 'select',
+  c: 'crop',
+  a: 'arrow',
+  t: 'text',
+  n: 'number',
+  p: 'pen',
+  r: 'rectangle',
+  o: 'circle',
+};
+
+const TOOL_LABELS: Record<Tool, string> = {
+  select: 'Select',
+  crop: 'Crop',
+  arrow: 'Arrow',
+  text: 'Text',
+  number: 'Number',
+  pen: 'Pen',
+  rectangle: 'Rectangle',
+  circle: 'Circle',
+};
+
+export const TOOL_SHORTCUTS: ToolShortcut[] = (Object.keys(TOOL_SHORTCUT_KEYS) as string[]).map(
+  (key) => {
+    const tool = TOOL_SHORTCUT_KEYS[key];
+    return {
+      id: `tool-${tool}`,
+      tool,
+      label: `Select ${TOOL_LABELS[tool]} tool`,
+      keys: key.toUpperCase(),
+      key,
+      category: 'tool' as const,
+    };
+  }
+);
+
+export type PaletteAction = 'full-screen' | 'select-area' | 'studio';
+
+export interface PaletteShortcut extends ShortcutDef {
+  category: 'palette';
+  action: PaletteAction;
+}
+
+export const PALETTE_SHORTCUTS: PaletteShortcut[] = [
+  {
+    id: 'palette-full-screen',
+    action: 'full-screen',
+    label: 'Take full screen screenshot',
+    keys: 'Alt+1',
+    key: '1',
+    alt: true,
+    category: 'palette',
+  },
+  {
+    id: 'palette-select-area',
+    action: 'select-area',
+    label: 'Take area screenshot',
+    keys: 'Alt+2',
+    key: '2',
+    alt: true,
+    category: 'palette',
+  },
+  {
+    id: 'palette-studio',
+    action: 'studio',
+    label: 'Open Studio',
+    keys: 'Alt+3',
+    key: '3',
+    alt: true,
+    category: 'palette',
+  },
+];
+
+export type AppAction = 'toggle-palette';
+
+export interface AppShortcut extends ShortcutDef {
+  category: 'app';
+  action: AppAction;
+}
+
+export const APP_SHORTCUTS: AppShortcut[] = [
+  {
+    id: 'app-toggle-palette',
+    action: 'toggle-palette',
+    label: 'Return to palette',
+    keys: 'Ctrl+Alt+S',
+    key: 's',
+    alt: true,
+    ctrl: true,
+    category: 'app',
+  },
+];
+
+
+export const ALL_SHORTCUTS: ShortcutDef[] = [
+  ...EDITOR_SHORTCUTS,
+  ...TOOL_SHORTCUTS,
+  ...PALETTE_SHORTCUTS,
+  ...APP_SHORTCUTS,
+];
+
+export function findShortcut(id: string): ShortcutDef | undefined {
+  return ALL_SHORTCUTS.find((s) => s.id === id);
+}
+
+export function getToolForShortcut(key: string): Tool | undefined {
+  return TOOL_SHORTCUT_KEYS[key.toLowerCase()];
+}
+
+export function matchesShortcut(shortcut: ShortcutDef, e: KeyboardEvent): boolean {
+  return (
+    e.altKey === !!shortcut.alt &&
+    e.ctrlKey === !!shortcut.ctrl &&
+    e.shiftKey === !!shortcut.shift &&
+    e.metaKey === !!shortcut.meta &&
+    e.key.toLowerCase() === shortcut.key.toLowerCase()
+  );
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable
+  );
+}
+


### PR DESCRIPTION
## Shortcuts

Add keyboard shortcuts for the app

### Editor

| Shortcut | Action |
|----------|--------|
| Enter | Edit selected text |
| Delete / Backspace | Delete selected shape |
| Ctrl+Z | Undo |
| Ctrl+Shift+Z | Redo |
| Ctrl+Y | Redo (alternate) |
| Ctrl+S | Export image |
| Ctrl+C | Copy shape |
| Ctrl+V | Paste shape |
| Ctrl+D | Duplicate shape |
| Escape | Deselect all |

### Tools

| Shortcut | Tool |
|----------|------|
| V | Select |
| C | Crop |
| A | Arrow |
| T | Text |
| N | Number |
| P | Pen |
| R | Rectangle |
| O | Circle |

### Palette

| Shortcut | Action |
|----------|--------|
| Alt+1 | Take full-screen screenshot |
| Alt+2 | Take area screenshot |
| Alt+3 | Open Studio |

### Application

| Shortcut | Action |
|----------|--------|
| Ctrl+Alt+S | Return to palette |