### PR TITLE
fix: fix text selection box width

### DIFF
--- a/frontend/src/components/editor/Canvas.tsx
+++ b/frontend/src/components/editor/Canvas.tsx
@@ -460,11 +460,27 @@ const Canvas = forwardRef<Konva.Stage, CanvasProps>(({
         : 'Text';
       const fillColor = selectedTool === 'number' ? '#ff3b30' : color;
       const style = selectedTool === 'number' ? 'bold' : '';
+      const fontSize = 24;
+      const fontFamily = 'Inter';
+      
+      const measureNode = new Konva.Text({
+        text,
+        fontSize,
+        fontFamily,
+        fontStyle: style,
+        padding: 4,
+      });
+      const measuredWidth = measureNode.width() * 8;
+      const measuredHeight = Math.max(fontSize * 1.2, measureNode.height());
+      measureNode.destroy();
+
       const textShape: ShapeConfig = {
         id, type: selectedTool === 'number' ? 'number' : 'text',
         x: pos.x, y: pos.y,
-        text, fill: fillColor, fillEnabled: true, fontSize: 24, fontFamily: 'Inter', fontStyle: style, opacity,
+        text, fill: fillColor, fillEnabled: true, fontSize, fontFamily, fontStyle: style, opacity,
         align: textAlign || 'left',
+        width: measuredWidth,
+        height: measuredHeight,
       };
       addShape(textShape);
       if (!isNumber) {


### PR DESCRIPTION
### Summary
Fix the box width when you create a new text.

### Problem
When you create a new text in the editor.
The selection box was **very wide**.

before:
<img width="1920" height="1043" alt="Screenshot From 2026-08-02 23-02-16" src="https://github.com/user-attachments/assets/eaac29a2-03de-4689-9c0e-7146e2a7dae9" />

After:
<img width="1920" height="1043" alt="Screenshot From 2026-08-02 23-03-05" src="https://github.com/user-attachments/assets/95c25b6c-4292-4f70-a063-83725bbb1813" />

### The fix:
In the line ~466 Canvas.tsx
```js
const measureNode = new Konva.Text({
        text,
        fontSize,
        fontFamily,
        fontStyle: style,
        padding: 4,
      });
      const measuredWidth = measureNode.width() * 8; // Here is the main change 
      const measuredHeight = Math.max(fontSize * 1.2, measureNode.height());
      measureNode.destroy();
```
