### PR TITLE
fix: Fix background & crop when it reset the image

### DIFF
--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -129,10 +129,8 @@ export default function Editor({ imageUrl, onBack }: EditorProps) {
       const maxH = window.innerHeight * 0.75;
       const baseScale = Math.min(maxW / img.width, maxH / img.height, 1);
       const pad = background.enabled ? background.padding : 0;
-      setStageSize({
-        width: img.width * baseScale + pad * 2,
-        height: img.height * baseScale + pad * 2,
-      });
+
+      setStageSize({ width: img.width * baseScale + pad * 2, height: img.height * baseScale + pad * 2 });
       setImageTransform({
         x: pad,
         y: pad,
@@ -141,14 +139,22 @@ export default function Editor({ imageUrl, onBack }: EditorProps) {
         rotation: 0,
       });
     };
-  }, [imageUrl, background.enabled, background.padding]);
+  }, [imageUrl]);
 
   useEffect(() => {
-    if (image) {
-      const pad = background.enabled ? background.padding : 0;
-      setImageTransform(prev => ({ ...prev, x: pad, y: pad }));
-    }
-  }, [background.padding, background.enabled, image]);
+    if (!image) return;
+    const pad = background.enabled ? background.padding : 0;
+    
+    setStageSize({
+      width: image.width * imageTransform.scaleX + pad * 2,
+      height: image.height * imageTransform.scaleY + pad * 2,
+    });
+    setImageTransform(prev => ({
+      ...prev,
+      x: pad,
+      y: pad,
+    }));
+  }, [background.enabled, background.padding, image, imageTransform.scaleX, imageTransform.scaleY]);
 
   useEffect(() => {
     if (!selectedId) return;


### PR DESCRIPTION
### Summery
Fix the bug in the issues [#29]

### The main problem
In Line ~122 Editor.tsx
```js
useEffect(() => {
    const img = new window.Image();
    img.crossOrigin = 'anonymous';
    img.src = imageUrl;
    img.onload = () => {
      setImage(img);
      const maxW = window.innerWidth * 0.8;
      const maxH = window.innerHeight * 0.75;
      const baseScale = Math.min(maxW / img.width, maxH / img.height, 1);
      const pad = background.enabled ? background.padding : 0;
      setStageSize({
        width: img.width * baseScale + pad * 2,
        height: img.height * baseScale + pad * 2,
      });
      setImageTransform({
        x: pad,
        y: pad,
        scaleX: baseScale,
        scaleY: baseScale,
        rotation: 0,
      });
    };
  }, [imageUrl, background.enabled, background.padding]);
```

`useEffect` have a `[imageUrl, background.enabled, background.padding]`
He will be run
```js
const img = new window.Image();
img.crossOrigin = 'anonymous';
img.src = imageUrl;
```
everytime you will be create a new background, from imageURL ( **The main pic you are edit before u doing crop**)

### The solve
- Removed `background.enabled` and `background.padding` from the image loading useEffect.
- The editor now loads the source image only when `imageUrl` changes
- Added a separate effect to update the stage size and image offset when the background padding changes
- This prevents the editor from reloading the original image whenever the background settings are modified, preserving the current crop

**Code in the line ~122 Editor.tsx**
```js
useEffect(() => {
    const img = new window.Image();
    img.crossOrigin = 'anonymous';
    img.src = imageUrl;
    img.onload = () => {
      setImage(img);
      const maxW = window.innerWidth * 0.8;
      const maxH = window.innerHeight * 0.75;
      const baseScale = Math.min(maxW / img.width, maxH / img.height, 1);
      const pad = background.enabled ? background.padding : 0;

      setStageSize({ width: img.width * baseScale + pad * 2, height: img.height * baseScale + pad * 2 });
      setImageTransform({
        x: pad,
        y: pad,
        scaleX: baseScale,
        scaleY: baseScale,
        rotation: 0,
      });
    };
  }, [imageUrl]);

  useEffect(() => {
    if (!image) return;
    const pad = background.enabled ? background.padding : 0;
    
    setStageSize({
      width: image.width * imageTransform.scaleX + pad * 2,
      height: image.height * imageTransform.scaleY + pad * 2,
    });
    setImageTransform(prev => ({
      ...prev,
      x: pad,
      y: pad,
    }));
  }, [background.enabled, background.padding, image, imageTransform.scaleX, imageTransform.scaleY]);
```