### PR TITLE
fix: fix float toolbar background color

### DIFF
--- a/frontend/src/components/editor/FloatingToolbar.tsx
+++ b/frontend/src/components/editor/FloatingToolbar.tsx
@@ -206,7 +206,7 @@ export default function FloatingToolbar({
           }}
         >
           <div className="-translate-x-1/2">
-            <div className="flex items-center gap-1.5 backdrop-blur-xl  border-white/10 rounded-xl mt-[3vh] shadow-2xl shadow-black/50">
+            <div className="flex items-center gap-1.5 backdrop-blur-xl bg-neutral-900/90 border-white/10 rounded-xl mt-[3vh] shadow-2xl shadow-black/50">
             <div className="flex items-center gap-1 bg-white/5 rounded-lg px-1.5 py-1">
               <Palette size={12} className="text-white/50 shrink-0" />
               <input


### PR DESCRIPTION
### Summery 
Change float toolbar background color

### Problem
When user making edit for the light photos, the toolbar will be hide

**Before:**

<img width="1256" height="912" alt="issues-toolbar" src="https://github.com/user-attachments/assets/0e5c7d65-d305-40cf-94b7-5a1c38d22ef3" />

**After:**
<img width="628" height="389" alt="Screenshot From 2026-08-04 16-45-47" src="https://github.com/user-attachments/assets/92796d54-d205-4947-8539-2f88071cae9f" />

**Solve:**
We just add a background color.