### PR TITLE
fix/feat: fix the app still record when you close the record & user can disable/enable mic and sound system while record

### DIFF
--- a/app.go
+++ b/app.go
@@ -171,6 +171,20 @@ func (a *App) CancelRecording() error {
 	return a.screenCastService.CancelRecording()
 }
 
+func (a *App) SetMicEnabled(enabled bool) error {
+	if a.screenCastService == nil {
+		return fmt.Errorf("recording service not initialized")
+	}
+	return a.screenCastService.SetMicEnabled(enabled)
+}
+
+func (a *App) SetSystemEnabled(enabled bool) error {
+	if a.screenCastService == nil {
+		return fmt.Errorf("recording service not initialized")
+	}
+	return a.screenCastService.SetSystemEnabled(enabled)
+}
+
 func (a *App) GetVideosDir() string {
 	dir, err := screencast.VideosDir()
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -45,6 +45,9 @@ func (a *App) startup(ctx context.Context) {
 
 	a.screenshotService = screenshot.NewService(conn)
 	a.screenCastService = screencast.NewScreenCastService(conn)
+	a.screenCastService.SetOnRecordingEnd(func() {
+		runtime.EventsEmit(a.ctx, "recording-ended")
+	})
 
 	home, _ := os.UserHomeDir()
 	screenshotsDir := filepath.Join(home, "Pictures", "Screenshots")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import {
   StopRecording,
   CancelRecording,
   SaveMicrophone,
+  SetMicEnabled,
+  SetSystemEnabled,
 } from '../wailsjs/go/main/App';
 import { AnimatePresence } from 'framer-motion';
 import Palette from './components/Palette';
@@ -87,6 +89,13 @@ export default function App() {
     }
   };
 
+  const handleToggleMic = (enabled: boolean) => {
+    SetMicEnabled(enabled).catch(err => console.error('SetMicEnabled failed:', err));
+  };
+  const handleToggleSystem = (enabled: boolean) => {
+    SetSystemEnabled(enabled).catch(err => console.error('SetSystemEnabled failed:', err));
+  };
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isEditableTarget(e.target)) return;
@@ -150,6 +159,8 @@ export default function App() {
             onResume={handleResume}
             onStop={handleStop}
             onCancel={handleCancel}
+            onToggleMic={handleToggleMic}
+            onToggleSystem={handleToggleSystem}
           />
         )}
       </AnimatePresence>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,19 +69,21 @@ export default function App() {
     try {
       const path = await StopRecording();
       console.log('Recording saved:', path);
-      setIsPaused(false);
-      switchToPalette();
     } catch (err) {
       console.error('StopRecording failed:', err);
+    } finally {
+      setIsPaused(false);
+      switchToPalette();
     }
   };
   const handleCancel = async () => {
     try {
       await CancelRecording();
-      setIsPaused(false);
-      switchToPalette();
     } catch (err) {
       console.error('CancelRecording failed:', err);
+    } finally {
+      setIsPaused(false);
+      switchToPalette();
     }
   };
 
@@ -106,6 +108,14 @@ export default function App() {
 
   useEffect(() => {
     const unsub = EventsOn('toggle-palette', switchToPalette);
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    const unsub = EventsOn('recording-ended', () => {
+      setIsPaused(false);
+      switchToPalette();
+    });
     return unsub;
   }, []);
 

--- a/frontend/src/components/RecordingBar.tsx
+++ b/frontend/src/components/RecordingBar.tsx
@@ -3,8 +3,10 @@ import { motion } from 'framer-motion';
 import { Pause, Play, Square, X, Mic, Volume2 } from 'lucide-react';
 import { RecordingBarProps } from '@/types/types';
 
-export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused }: RecordingBarProps) {
+export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused, onToggleMic, onToggleSystem }: RecordingBarProps) {
   const [seconds, setSeconds] = useState(0);
+  const [micOn, setMicOn] = useState(true);
+  const [systemOn, setSystemOn] = useState(true);
   const timerRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -22,6 +24,18 @@ export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPa
     const m = Math.floor(secs / 60);
     const s = secs % 60;
     return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+  };
+
+  const toggleMic = () => {
+    const next = !micOn;
+    onToggleMic(next);
+    setMicOn(next);
+  };
+
+  const toggleSystem = () => {
+    const next = !systemOn;
+    onToggleSystem(next);
+    setSystemOn(next);
   };
 
   return (
@@ -62,14 +76,22 @@ export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPa
 
       <div className="h-6 w-px bg-white/20" />
 
-      <div className="flex items-center gap-1.5 text-xs text-white/70">
-        <Mic size={14}  />
+      <button
+        onClick={toggleMic}
+        className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded-lg transition-colors ${micOn ? 'text-white text-red-400' : 'text-white/35 line-through'}`}
+        title={micOn ? 'Mute microphone' : 'Unmute microphone'}
+      >
+        <Mic size={14} />
         <span>Mic</span>
-      </div>
-      <div className="flex items-center gap-1.5 text-xs text-white/70">
-        <Volume2 size={14}  />
+      </button>
+      <button
+        onClick={toggleSystem}
+        className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded-lg transition-colors ${systemOn ? 'text-white text-red-400' : 'text-white/35 line-through'}`}
+        title={systemOn ? 'Mute system audio' : 'Unmute system audio'}
+      >
+        <Volume2 size={14} />
         <span>System</span>
-      </div>
+      </button>
     </motion.div>
   );
 }

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -42,6 +42,8 @@ export interface RecordingBarProps {
   onResume: () => void;
   onCancel: () => void;
   isPaused: boolean;
+  onToggleMic: (enabled: boolean) => void;
+  onToggleSystem: (enabled: boolean) => void;
 }
 
 export interface RecordingSettingsProps {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -39,6 +39,10 @@ export function SaveFileDialog(arg1:string):Promise<string>;
 
 export function SaveMicrophone(arg1:string):Promise<void>;
 
+export function SetMicEnabled(arg1:boolean):Promise<void>;
+
+export function SetSystemEnabled(arg1:boolean):Promise<void>;
+
 export function StartRecording(arg1:boolean,arg2:boolean,arg3:string):Promise<string>;
 
 export function StopRecording():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -74,6 +74,14 @@ export function SaveMicrophone(arg1) {
   return window['go']['main']['App']['SaveMicrophone'](arg1);
 }
 
+export function SetMicEnabled(arg1) {
+  return window['go']['main']['App']['SetMicEnabled'](arg1);
+}
+
+export function SetSystemEnabled(arg1) {
+  return window['go']['main']['App']['SetSystemEnabled'](arg1);
+}
+
 export function StartRecording(arg1, arg2, arg3) {
   return window['go']['main']['App']['StartRecording'](arg1, arg2, arg3);
 }

--- a/services/screencast/audio.go
+++ b/services/screencast/audio.go
@@ -32,6 +32,18 @@ func pactlOutput(args ...string) ([]byte, error) {
 	return exec.Command("pactl", args...).Output()
 }
 
+func setSourceMute(name string, muted bool) error {
+	value := "0"
+	if muted {
+		value = "1"
+	}
+	cmd := exec.Command("pactl", "set-source-mute", name, value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("pactl set-source-mute %s %s: %v (%s)", name, value, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 func listSources() ([]pactlSource, error) {
 	out, err := pactlOutput("list", "sources")
 	if err != nil {

--- a/services/screencast/recorder.go
+++ b/services/screencast/recorder.go
@@ -37,6 +37,8 @@ type gstLauncher struct {
 	waitSet bool
 }
 
+var gstLaunchBinary = "gst-launch-1.0"
+
 func NewGstLauncher() Recorder {
 	return &gstLauncher{}
 }
@@ -54,7 +56,7 @@ func (g *gstLauncher) Start(videoNode uint32, opts RecordingOptions) error {
 		return err
 	}
 
-	cmd := exec.Command("gst-launch-1.0", args...)
+	cmd := exec.Command(gstLaunchBinary, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -71,6 +73,9 @@ func (g *gstLauncher) Start(videoNode uint32, opts RecordingOptions) error {
 		g.mu.Lock()
 		g.waitErr = waitErr
 		g.waitSet = true
+		g.cmd = nil
+		g.paused = false
+		g.done = nil
 		g.mu.Unlock()
 		close(done)
 	}()

--- a/services/screencast/recorder_test.go
+++ b/services/screencast/recorder_test.go
@@ -1,0 +1,94 @@
+package screencast
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func fakeGstLaunchBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "fake-gst-launch")
+	script := "#!/bin/sh\nexec sleep 30\n"
+	if err := os.WriteFile(bin, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func withFakeGstLaunch(t *testing.T) {
+	t.Helper()
+	original := gstLaunchBinary
+	gstLaunchBinary = fakeGstLaunchBinary(t)
+	t.Cleanup(func() { gstLaunchBinary = original })
+}
+
+func TestRecorderCanRestartAfterStop(t *testing.T) {
+	withFakeGstLaunch(t)
+
+	rec := NewGstLauncher()
+	gst := rec.(*gstLauncher)
+
+	opts := RecordingOptions{OutputPath: filepath.Join(t.TempDir(), "out.mp4")}
+
+	if err := rec.Start(1, opts); err != nil {
+		t.Fatalf("first Start failed: %v", err)
+	}
+	if !rec.IsRunning() {
+		t.Fatal("expected recording to be running after Start")
+	}
+
+	if err := rec.Stop(); err != nil {
+		if !strings.Contains(err.Error(), "interrupt") {
+			t.Fatalf("Stop failed: %v", err)
+		}
+	}
+	if rec.IsRunning() {
+		t.Fatal("expected recording to be stopped after Stop")
+	}
+
+	gst.mu.Lock()
+	stale := gst.cmd != nil || gst.done != nil || gst.paused
+	gst.mu.Unlock()
+	if stale {
+		t.Fatalf("gstLauncher state was not cleared after the process exited: cmd=%v done=%v paused=%v",
+			gst.cmd != nil, gst.done != nil, gst.paused)
+	}
+
+	if err := rec.Start(1, opts); err != nil {
+		t.Fatalf("second Start failed (recorder not reusable): %v", err)
+	}
+	if !rec.IsRunning() {
+		t.Fatal("expected second recording to be running")
+	}
+
+	if err := rec.Stop(); err != nil {
+		if !strings.Contains(err.Error(), "interrupt") {
+			t.Fatalf("second Stop failed: %v", err)
+		}
+	}
+	if rec.IsRunning() {
+		t.Fatal("expected second recording to be stopped")
+	}
+}
+
+func TestRecorderRejectsConcurrentStart(t *testing.T) {
+	withFakeGstLaunch(t)
+
+	rec := NewGstLauncher()
+	opts := RecordingOptions{OutputPath: filepath.Join(t.TempDir(), "out.mp4")}
+
+	if err := rec.Start(1, opts); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer func() {
+		_ = rec.Cancel()
+	}()
+
+	if err := rec.Start(1, opts); err == nil {
+		t.Fatal("expected second concurrent Start to fail")
+	} else if !strings.Contains(err.Error(), "recording already active") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/services/screencast/screencast.go
+++ b/services/screencast/screencast.go
@@ -15,16 +15,22 @@ type StreamInfo struct {
 }
 
 type ScreenCastService struct {
-	conn          *dbus.Conn
-	recorder      Recorder
-	sessionHandle dbus.ObjectPath
-	videoNode     uint32
-	recording     bool
-	stopRequested bool
-	outputPath    string
-	finished      chan struct{}
-	mu            chan struct{}
+	conn           *dbus.Conn
+	recorder       Recorder
+	sessionHandle  dbus.ObjectPath
+	videoNode      uint32
+	recording      bool
+	stopRequested  bool
+	outputPath     string
+	finished       chan struct{}
+	mu             chan struct{}
 	onRecordingEnd func()
+	captureMic     bool
+	captureSystem  bool
+	micDevice      string
+	systemDevice   string
+	micEnabled     bool
+	systemEnabled  bool
 }
 
 func NewScreenCastService(conn *dbus.Conn) *ScreenCastService {
@@ -51,6 +57,36 @@ func (s *ScreenCastService) notifyRecordingEnd() {
 	if fn != nil {
 		fn()
 	}
+}
+
+func (s *ScreenCastService) SetMicEnabled(enabled bool) error {
+	s.lock()
+	recording := s.recording
+	captureMic := s.captureMic
+	device := s.micDevice
+	s.unlock()
+	if !recording || !captureMic {
+		return fmt.Errorf("no microphone recording active")
+	}
+	if device == "" {
+		return fmt.Errorf("microphone device unavailable")
+	}
+	return setSourceMute(device, !enabled)
+}
+
+func (s *ScreenCastService) SetSystemEnabled(enabled bool) error {
+	s.lock()
+	recording := s.recording
+	captureSystem := s.captureSystem
+	device := s.systemDevice
+	s.unlock()
+	if !recording || !captureSystem {
+		return fmt.Errorf("no system audio recording active")
+	}
+	if device == "" {
+		return fmt.Errorf("system audio device unavailable")
+	}
+	return setSourceMute(device, !enabled)
 }
 
 func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDevice string) (string, error) {
@@ -118,6 +154,12 @@ func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDe
 	s.recording = true
 	s.stopRequested = false
 	s.finished = make(chan struct{})
+	s.captureMic = opts.CaptureMic
+	s.captureSystem = opts.CaptureSystem
+	s.micDevice = opts.MicDevice
+	s.systemDevice = opts.SystemDevice
+	s.micEnabled = opts.CaptureMic
+	s.systemEnabled = opts.CaptureSystem
 	finished := s.finished
 	s.unlock()
 
@@ -137,6 +179,12 @@ func (s *ScreenCastService) monitor(finished chan struct{}) {
 	s.videoNode = 0
 	s.outputPath = ""
 	s.finished = nil
+	s.captureMic = false
+	s.captureSystem = false
+	s.micDevice = ""
+	s.systemDevice = ""
+	s.micEnabled = false
+	s.systemEnabled = false
 	close(finished)
 	s.unlock()
 

--- a/services/screencast/screencast.go
+++ b/services/screencast/screencast.go
@@ -24,6 +24,7 @@ type ScreenCastService struct {
 	outputPath    string
 	finished      chan struct{}
 	mu            chan struct{}
+	onRecordingEnd func()
 }
 
 func NewScreenCastService(conn *dbus.Conn) *ScreenCastService {
@@ -36,6 +37,21 @@ func NewScreenCastService(conn *dbus.Conn) *ScreenCastService {
 
 func (s *ScreenCastService) lock()   { s.mu <- struct{}{} }
 func (s *ScreenCastService) unlock() { <-s.mu }
+
+func (s *ScreenCastService) SetOnRecordingEnd(fn func()) {
+	s.lock()
+	s.onRecordingEnd = fn
+	s.unlock()
+}
+
+func (s *ScreenCastService) notifyRecordingEnd() {
+	s.lock()
+	fn := s.onRecordingEnd
+	s.unlock()
+	if fn != nil {
+		fn()
+	}
+}
 
 func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDevice string) (string, error) {
 	s.lock()
@@ -129,6 +145,8 @@ func (s *ScreenCastService) monitor(finished chan struct{}) {
 	if recording && !stopRequested && waitErr != nil {
 		fmt.Printf("screencast: gst-launch exited unexpectedly: %v\n", waitErr)
 	}
+
+	s.notifyRecordingEnd()
 }
 
 func (s *ScreenCastService) PauseRecording() error {


### PR DESCRIPTION
## Summary
fixes an issue where screen recording could continue running after the recording window was closed. It also introduces the ability to enable or disable the microphone and system audio while a recording is already in progress.

## Changes
- Fixed the recording lifecycle so recording properly stops when the recording session ends or the recording window is closed.
- Added a recording completion event to keep the UI synchronized with the backend recording state.
- Added runtime controls to enable or disable:
  - Microphone recording
  - System audio recording
- Exposed new backend APIs:
  - `SetMicEnabled()`
  - `SetSystemEnabled()`
- Updated the recording toolbar with microphone and system audio toggle buttons.
- Improved recorder state cleanup after the GStreamer process exits, allowing the recorder to be reused safely.
- Added unit tests covering recorder restart behavior and preventing concurrent recording sessions.