### PR TITLE
fix: Canceling a recording still saves the video file

### DIFF
--- a/services/screencast/recorder_test.go
+++ b/services/screencast/recorder_test.go
@@ -92,3 +92,40 @@ func TestRecorderRejectsConcurrentStart(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestCancelRecordingDiscardsOutputFile(t *testing.T) {
+	withFakeGstLaunch(t)
+
+	s := &ScreenCastService{
+		recorder: NewGstLauncher(),
+		mu:       make(chan struct{}, 1),
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.mp4")
+
+	if err := s.recorder.Start(1, RecordingOptions{OutputPath: outPath}); err != nil {
+		t.Fatalf("recorder Start failed: %v", err)
+	}
+
+	s.recording = true
+	s.outputPath = outPath
+	s.finished = make(chan struct{})
+	go s.monitor(s.finished)
+
+	if err := os.WriteFile(outPath, []byte("partial-data"), 0644); err != nil {
+		t.Fatalf("write partial output failed: %v", err)
+	}
+
+	if err := s.CancelRecording(); err != nil {
+		t.Fatalf("CancelRecording returned error: %v", err)
+	}
+
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Fatalf("expected canceled recording output file to be removed, but it still exists (stat err=%v)", err)
+	}
+	if s.recording {
+		t.Fatal("expected recording flag to be cleared after cancel")
+	}
+}
+

--- a/services/screencast/screencast.go
+++ b/services/screencast/screencast.go
@@ -249,15 +249,15 @@ func (s *ScreenCastService) CancelRecording() error {
 	s.stopRequested = true
 	s.unlock()
 
-	if err := s.recorder.Cancel(); err != nil {
-		return err
-	}
+	_ = s.recorder.Cancel()
 
 	if finished != nil {
 		<-finished
 	}
 	if path != "" {
-		os.Remove(path)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to discard canceled recording: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
When canceling a recording, the recorded video is still saved to disk.

A canceled recording should be completely discarded and no output file should be created.

### Steps to Reproduce
1. Start a screen recording.
2. Record for a few seconds.
3. Click **Cancel** instead of **Stop**.
4. Check the output directory.

### Before
The recording is canceled, but the video file is still saved in the output directory.

### Now
Canceling a recording should discard the recording entirely. No video file should be saved, and any temporary recording data should be cleaned up.

**Function:**
```go
func (s *ScreenCastService) CancelRecording() error {
	s.lock()
	if !s.recording {
		s.unlock()
		return fmt.Errorf("no active recording")
	}
	path := s.outputPath
	finished := s.finished
	s.stopRequested = true
	s.unlock()

	_ = s.recorder.Cancel()
       # Edit was here
	if finished != nil {
		<-finished
	}
	if path != "" {
		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
			return fmt.Errorf("failed to discard canceled recording: %w", err)
		}
	}
	return nil
}
```