### PR TITLE
Preserve audio toggle state between main screen and recording controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,8 @@ import { WindowMode } from './types/types';
 export default function App() {
   const [mode, setMode] = useState<WindowMode>('palette');
   const [isPaused, setIsPaused] = useState(false);
+  const [recMicEnabled, setRecMicEnabled] = useState(true);
+  const [recSystemEnabled, setRecSystemEnabled] = useState(true);
 
   const switchToPalette = () => {
     setMode('palette');
@@ -55,6 +57,8 @@ export default function App() {
     }
     await StartRecording(micOn, systemOn, micDevice);
     setIsPaused(false);
+    setRecMicEnabled(micOn);
+    setRecSystemEnabled(systemOn);
     setMode('recording');
     ResizeToPalette();
   };
@@ -155,6 +159,8 @@ export default function App() {
         {mode === 'recording' && (
           <RecordingBar
             isPaused={isPaused}
+            micEnabled={recMicEnabled}
+            systemEnabled={recSystemEnabled}
             onPause={handlePause}
             onResume={handleResume}
             onStop={handleStop}

--- a/frontend/src/components/RecordingBar.tsx
+++ b/frontend/src/components/RecordingBar.tsx
@@ -3,10 +3,10 @@ import { motion } from 'framer-motion';
 import { Pause, Play, Square, X, Mic, Volume2 } from 'lucide-react';
 import { RecordingBarProps } from '@/types/types';
 
-export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused, onToggleMic, onToggleSystem }: RecordingBarProps) {
+export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused, micEnabled, systemEnabled, onToggleMic, onToggleSystem }: RecordingBarProps) {
   const [seconds, setSeconds] = useState(0);
-  const [micOn, setMicOn] = useState(true);
-  const [systemOn, setSystemOn] = useState(true);
+  const [micOn, setMicOn] = useState(micEnabled);
+  const [systemOn, setSystemOn] = useState(systemEnabled);
   const timerRef = useRef<number | null>(null);
 
   useEffect(() => {

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -42,6 +42,8 @@ export interface RecordingBarProps {
   onResume: () => void;
   onCancel: () => void;
   isPaused: boolean;
+  micEnabled: boolean;
+  systemEnabled: boolean;
   onToggleMic: (enabled: boolean) => void;
   onToggleSystem: (enabled: boolean) => void;
 }

--- a/services/screencast/screencast.go
+++ b/services/screencast/screencast.go
@@ -129,23 +129,29 @@ func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDe
 	}
 
 	opts := RecordingOptions{OutputPath: outPath}
-	if captureMic {
-		if micDevice == "" {
-			micDevice = DefaultMicrophone()
-		}
+
+	if micDevice == "" {
+		micDevice = DefaultMicrophone()
+	}
+	if micDevice != "" {
 		opts.CaptureMic = true
 		opts.MicDevice = micDevice
 	}
-	if captureSystem {
-		if device, err := SystemAudioDevice(); err == nil {
-			opts.CaptureSystem = true
-			opts.SystemDevice = device
-		}
+	if device, err := SystemAudioDevice(); err == nil && device != "" {
+		opts.CaptureSystem = true
+		opts.SystemDevice = device
 	}
 
 	if err := s.recorder.Start(videoNode, opts); err != nil {
 		s.closeSession()
 		return "", err
+	}
+
+	if opts.CaptureMic && !captureMic {
+		_ = setSourceMute(opts.MicDevice, true)
+	}
+	if opts.CaptureSystem && !captureSystem {
+		_ = setSourceMute(opts.SystemDevice, true)
 	}
 
 	s.lock()
@@ -158,8 +164,8 @@ func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDe
 	s.captureSystem = opts.CaptureSystem
 	s.micDevice = opts.MicDevice
 	s.systemDevice = opts.SystemDevice
-	s.micEnabled = opts.CaptureMic
-	s.systemEnabled = opts.CaptureSystem
+	s.micEnabled = captureMic
+	s.systemEnabled = captureSystem
 	finished := s.finished
 	s.unlock()
 


### PR DESCRIPTION
### Description
When disabling the **Microphone** and/or **System Audio** from the recording settings before starting a recording, the recording toolbar does not reflect those settings.
The recording toolbar shows both options as enabled, even though they were disabled in the settings screen.

### Before
The recording toolbar displays the Microphone and System Audio controls as enabled, even though they were disabled before starting the recording.

### Now
The recording toolbar should preserve the user's selected settings. If Microphone or System Audio is disabled in the settings, it should also appear disabled in the recording toolbar.