### PR TITLE
Fix: First recording starts ~4 seconds in the UI, behind real elapsed

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,6 +48,9 @@ func (a *App) startup(ctx context.Context) {
 	a.screenCastService.SetOnRecordingEnd(func() {
 		runtime.EventsEmit(a.ctx, "recording-ended")
 	})
+	a.screenCastService.SetOnRecordingStart(func() {
+		runtime.EventsEmit(a.ctx, "recording-started")
+	})
 
 	home, _ := os.UserHomeDir()
 	screenshotsDir := filepath.Join(home, "Pictures", "Screenshots")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { WindowMode } from './types/types';
 export default function App() {
   const [mode, setMode] = useState<WindowMode>('palette');
   const [isPaused, setIsPaused] = useState(false);
+  const [recStarted, setRecStarted] = useState(false);
   const [recMicEnabled, setRecMicEnabled] = useState(true);
   const [recSystemEnabled, setRecSystemEnabled] = useState(true);
 
@@ -56,6 +57,7 @@ export default function App() {
       await SaveMicrophone(micDevice);
     }
     await StartRecording(micOn, systemOn, micDevice);
+    setRecStarted(false);
     setIsPaused(false);
     setRecMicEnabled(micOn);
     setRecSystemEnabled(systemOn);
@@ -78,6 +80,7 @@ export default function App() {
     } catch (err) {
       console.error('StopRecording failed:', err);
     } finally {
+      setRecStarted(false);
       setIsPaused(false);
       switchToPalette();
     }
@@ -88,6 +91,7 @@ export default function App() {
     } catch (err) {
       console.error('CancelRecording failed:', err);
     } finally {
+      setRecStarted(false);
       setIsPaused(false);
       switchToPalette();
     }
@@ -125,7 +129,15 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    const unsub = EventsOn('recording-started', () => {
+      setRecStarted(true);
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
     const unsub = EventsOn('recording-ended', () => {
+      setRecStarted(false);
       setIsPaused(false);
       switchToPalette();
     });
@@ -159,6 +171,7 @@ export default function App() {
         {mode === 'recording' && (
           <RecordingBar
             isPaused={isPaused}
+            started={recStarted}
             micEnabled={recMicEnabled}
             systemEnabled={recSystemEnabled}
             onPause={handlePause}

--- a/frontend/src/components/RecordingBar.tsx
+++ b/frontend/src/components/RecordingBar.tsx
@@ -3,15 +3,20 @@ import { motion } from 'framer-motion';
 import { Pause, Play, Square, X, Mic, Volume2 } from 'lucide-react';
 import { RecordingBarProps } from '@/types/types';
 
-export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused, micEnabled, systemEnabled, onToggleMic, onToggleSystem }: RecordingBarProps) {
+export default function RecordingBar({ onStop, onPause, onResume, onCancel, isPaused, started, micEnabled, systemEnabled, onToggleMic, onToggleSystem }: RecordingBarProps) {
   const [seconds, setSeconds] = useState(0);
   const [micOn, setMicOn] = useState(micEnabled);
   const [systemOn, setSystemOn] = useState(systemEnabled);
   const timerRef = useRef<number | null>(null);
+  const startedRef = useRef(started);
+
+  useEffect(() => {
+    startedRef.current = started;
+  }, [started]);
 
   useEffect(() => {
     timerRef.current = window.setInterval(() => {
-      if (!isPaused) {
+      if (startedRef.current && !isPaused) {
         setSeconds(s => s + 1);
       }
     }, 1000);

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -42,6 +42,7 @@ export interface RecordingBarProps {
   onResume: () => void;
   onCancel: () => void;
   isPaused: boolean;
+  started: boolean;
   micEnabled: boolean;
   systemEnabled: boolean;
   onToggleMic: (enabled: boolean) => void;

--- a/services/screencast/screencast.go
+++ b/services/screencast/screencast.go
@@ -15,22 +15,23 @@ type StreamInfo struct {
 }
 
 type ScreenCastService struct {
-	conn           *dbus.Conn
-	recorder       Recorder
-	sessionHandle  dbus.ObjectPath
-	videoNode      uint32
-	recording      bool
-	stopRequested  bool
-	outputPath     string
-	finished       chan struct{}
-	mu             chan struct{}
-	onRecordingEnd func()
-	captureMic     bool
-	captureSystem  bool
-	micDevice      string
-	systemDevice   string
-	micEnabled     bool
-	systemEnabled  bool
+	conn             *dbus.Conn
+	recorder         Recorder
+	sessionHandle    dbus.ObjectPath
+	videoNode        uint32
+	recording        bool
+	stopRequested    bool
+	outputPath       string
+	finished         chan struct{}
+	mu               chan struct{}
+	onRecordingEnd   func()
+	onRecordingStart func()
+	captureMic       bool
+	captureSystem    bool
+	micDevice        string
+	systemDevice     string
+	micEnabled       bool
+	systemEnabled    bool
 }
 
 func NewScreenCastService(conn *dbus.Conn) *ScreenCastService {
@@ -50,10 +51,29 @@ func (s *ScreenCastService) SetOnRecordingEnd(fn func()) {
 	s.unlock()
 }
 
+func (s *ScreenCastService) SetOnRecordingStart(fn func()) {
+	s.lock()
+	s.onRecordingStart = fn
+	s.unlock()
+}
+
 func (s *ScreenCastService) notifyRecordingEnd() {
 	s.lock()
 	fn := s.onRecordingEnd
 	s.unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func (s *ScreenCastService) notifyRecordingStart() {
+	s.lock()
+	recording := s.recording
+	fn := s.onRecordingStart
+	s.unlock()
+	if !recording {
+		return
+	}
 	if fn != nil {
 		fn()
 	}
@@ -170,8 +190,34 @@ func (s *ScreenCastService) StartRecording(captureMic, captureSystem bool, micDe
 	s.unlock()
 
 	go s.monitor(finished)
+	go s.monitorCaptureStart(outPath)
 
 	return outPath, nil
+}
+
+func (s *ScreenCastService) monitorCaptureStart(outputPath string) {
+	const pollInterval = 50 * time.Millisecond
+	const timeout = 30 * time.Second
+
+	deadline := time.Now().Add(timeout)
+	var lastSize int64 = -1
+
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(outputPath); err == nil {
+			size := info.Size()
+			if lastSize == -1 {
+				lastSize = size
+			} else if size > lastSize {
+				s.notifyRecordingStart()
+				return
+			} else {
+				lastSize = size
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+
+	s.notifyRecordingStart()
 }
 
 func (s *ScreenCastService) monitor(finished chan struct{}) {

--- a/services/screencast/screencast_test.go
+++ b/services/screencast/screencast_test.go
@@ -1,6 +1,8 @@
 package screencast
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -100,5 +102,75 @@ func TestBuildPipelineArgsBoth(t *testing.T) {
 func TestBuildPipelineArgsEmptyPath(t *testing.T) {
 	if _, err := buildPipelineArgs(1, RecordingOptions{}); err == nil {
 		t.Fatal("expected error for empty output path")
+	}
+}
+
+func TestMonitorCaptureStartNotifiesWhenFileGrows(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.mp4")
+
+	notified := make(chan struct{}, 1)
+	s := &ScreenCastService{
+		recording:        true,
+		mu:               make(chan struct{}, 1),
+		onRecordingStart: func() { notified <- struct{}{} },
+	}
+
+	go s.monitorCaptureStart(outPath)
+
+	if err := os.WriteFile(outPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	f, err := os.OpenFile(outPath, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("video-data")); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	select {
+	case <-notified:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected start notification once the output file began growing")
+	}
+}
+
+func TestMonitorCaptureStartSuppressedWhenNotRecording(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.mp4")
+
+	notified := make(chan struct{}, 1)
+	s := &ScreenCastService{
+		recording: false, 
+		mu:        make(chan struct{}, 1),
+		onRecordingStart: func() {
+			select {
+			case notified <- struct{}{}:
+			default:
+			}
+		},
+	}
+
+	go s.monitorCaptureStart(outPath)
+
+	if err := os.WriteFile(outPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := os.WriteFile(outPath, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-notified:
+		t.Fatal("start notification should be suppressed when recording is no longer active")
+	case <-time.After(300 * time.Millisecond):
+		// success
 	}
 }

--- a/services/screencast/screencast_test.go
+++ b/services/screencast/screencast_test.go
@@ -147,7 +147,7 @@ func TestMonitorCaptureStartSuppressedWhenNotRecording(t *testing.T) {
 
 	notified := make(chan struct{}, 1)
 	s := &ScreenCastService{
-		recording: false, 
+		recording: false,
 		mu:        make(chan struct{}, 1),
 		onRecordingStart: func() {
 			select {


### PR DESCRIPTION
## What changed

Fixed the recording timer synchronization issue where the timer started before the actual video capture began.

Changes include:
- Added backend detection for the real recording start time by monitoring when the output file begins growing.
- Added a new `recording-started` event from the backend.
- Updated the frontend recording timer to start counting only after actual capture begins.
- Added tests to verify recording start detection behavior.

## Why it changed

The recording timer was starting immediately after the recording process was launched, but the actual video capture could begin several seconds later due to GStreamer initialization.

This caused the timer to be ahead of the recorded video duration, especially on the first recording after launching the application.

## How it was tested

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -w` applied
- `npm run build`

All checks passed successfully.

## Screenshots

N/A

## Notes

The timer now remains at `00:00` during the recording pipeline initialization and starts only when frames are actually being captured.

This keeps the timer synchronized with the final recorded video duration, including the first recording after application startup.

---

## Checklist

- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [ ] Screenshots added for UI changes 