### PR TITLE
feat: add custom fonts

### DIFF
--- a/frontend/src/components/Studio.tsx
+++ b/frontend/src/components/Studio.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../wailsjs/go/main/App";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import Editor from "@/components/editor/Editor";
+import { CustomFontsProvider } from "@/lib/customFonts";
 import { Button } from "./ui/button";
 
 function useDebounce<T>(value: T, delay: number): T {
@@ -335,7 +336,11 @@ export default function Studio({ onBackToPalette }: StudioProps) {
 
   if (selectedImage) {
     const imageUrl = `${baseUrl}/${encodeURIComponent(selectedImage.name)}`;
-    return <Editor imageUrl={imageUrl} onBack={handleBackToGallery} />;
+    return (
+      <CustomFontsProvider>
+        <Editor imageUrl={imageUrl} onBack={handleBackToGallery} />
+      </CustomFontsProvider>
+    );
   }
 
   return (

--- a/frontend/src/components/editor/FloatingToolbar.tsx
+++ b/frontend/src/components/editor/FloatingToolbar.tsx
@@ -21,6 +21,7 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { Toggle } from "@/components/ui/toggle";
 import { ShapeConfig } from "@/types/types";
+import FontPicker from "./FontPicker";
 
 interface FloatingToolbarProps {
   selectedShape: ShapeConfig | null;
@@ -315,21 +316,12 @@ export default function FloatingToolbar({
                   <div className="w-px h-6 bg-white/10" />
 
                   <div className="bg-white/5 rounded-lg px-1.5 py-1">
-                    <select
+                    <FontPicker
                       value={fontFamily}
-                      onChange={(e) => setFontFamily(e.target.value)}
-                      className="bg-transparent text-[10px] text-white/90 border border-white/10 rounded px-1 py-0.5 focus:outline-none focus:border-white/30 appearance-none cursor-pointer w-16"
-                    >
-                      {["Inter", "Arial", "Courier New", "Georgia"].map((f) => (
-                        <option
-                          key={f}
-                          value={f}
-                          className="bg-gray-900 text-white"
-                        >
-                          {f}
-                        </option>
-                      ))}
-                    </select>
+                      onChange={setFontFamily}
+                      selectClassName="text-[10px] px-1 py-0.5"
+                      optionClassName="bg-gray-900 text-white"
+                    />
                   </div>
 
                   <div className="w-px h-6 bg-white/10" />

--- a/frontend/src/components/editor/FontPicker.tsx
+++ b/frontend/src/components/editor/FontPicker.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Loader2, Plus, Trash2, Upload } from "lucide-react";
+import { useCustomFonts } from "@/lib/customFonts";
+
+interface FontPickerProps {
+  value: string;
+  onChange: (family: string) => void;
+  selectClassName?: string;
+  optionClassName?: string;
+}
+
+const selectBase =
+  "bg-transparent text-white/90 border border-white/10 rounded focus:outline-none focus:border-white/30 appearance-none cursor-pointer";
+
+export default function FontPicker({
+  value,
+  onChange,
+  selectClassName = "text-xs px-1.5 py-0.5",
+  optionClassName = "bg-gray-800 text-white",
+}: FontPickerProps) {
+  const { customFonts, builtinFonts, addFont, removeFont, acceptExtensions } =
+    useCustomFonts();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "error" | "info";
+    text: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [menuOpen]);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const added = await addFont(file);
+      onChange(added.name);
+      setMessage({ type: "info", text: `Added "${added.name}".` });
+    } catch (err) {
+      setMessage({
+        type: "error",
+        text: err instanceof Error ? err.message : "Could not add font.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async (id: string, name: string) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      await removeFont(id);
+      if (value.toLowerCase() === name.toLowerCase()) {
+        onChange("");
+      }
+      setMessage({ type: "info", text: `Removed "${name}".` });
+    } catch {
+      setMessage({ type: "error", text: "Could not remove the font." });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div ref={menuRef} className="relative flex items-center gap-1">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`${selectBase} ${selectClassName}`}
+      >
+        {builtinFonts.map((f) => (
+          <option key={f} value={f} className={optionClassName}>
+            {f}
+          </option>
+        ))}
+        {customFonts.length > 0 && (
+          <optgroup label="Custom Fonts">
+            {customFonts.map((c) => (
+              <option key={c.id} value={c.name} className={optionClassName}>
+                {c.name}
+                {c.loaded ? "" : " (unavailable)"}
+              </option>
+            ))}
+          </optgroup>
+        )}
+      </select>
+
+      <button
+        type="button"
+        onClick={() => setMenuOpen((v) => !v)}
+        className="p-1 bg-white/5 hover:bg-white/20 text-white/60 hover:text-white rounded transition-colors"
+        title="Add or manage custom fonts"
+        disabled={busy}
+      >
+        {busy ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <Plus size={12} />
+        )}
+      </button>
+
+      {menuOpen && (
+        <div className="absolute top-full right-0 mt-1 z-50 w-60 rounded-xl border border-white/10 bg-[#181818] shadow-2xl p-1.5 text-left">
+          <input
+            ref={fileRef}
+            type="file"
+            accept={acceptExtensions}
+            className="hidden"
+            onChange={handleFile}
+          />
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-xs text-white/80 hover:bg-white/10 transition-colors"
+          >
+            <Upload size={13} className="text-white/50" />
+            Upload font (.ttf, .otf, .woff, .woff2)
+          </button>
+          <div className="my-1 h-px bg-white/10" />
+          <div className="px-2.5 pb-1 text-[10px] uppercase tracking-wider text-white/40">
+            Custom fonts
+          </div>
+          {customFonts.length === 0 ? (
+            <div className="px-2.5 py-1.5 text-xs text-white/40">
+              No custom fonts yet.
+            </div>
+          ) : (
+            customFonts.map((c) => (
+              <div
+                key={c.id}
+                className="group flex items-center gap-2 px-2.5 py-1.5 rounded-lg hover:bg-white/10"
+              >
+                <span className="flex-1 truncate text-xs text-white/80">
+                  {c.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(c.id, c.name)}
+                  className="text-white/40 hover:text-red-400 transition-colors"
+                  title={`Remove ${c.name}`}
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))
+          )}
+          {message && (
+            <div
+              className={`mt-1 px-2.5 py-1 text-[11px] leading-tight rounded-lg ${
+                message.type === "error"
+                  ? "text-red-400 bg-red-500/10"
+                  : "text-white/70 bg-white/5"
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/editor/OptionsBar.tsx
+++ b/frontend/src/components/editor/OptionsBar.tsx
@@ -20,6 +20,7 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { Toggle } from "@/components/ui/toggle";
 import { Tool } from "@/types/types";
+import FontPicker from "./FontPicker";
 
 interface OptionsBarProps {
   selectedTool: Tool;
@@ -253,17 +254,12 @@ export default function OptionsBar({
 
           <div className="flex items-center gap-1.5 bg-white/5 rounded-lg px-2 py-1">
             <Type size={13} className="text-white/50" />
-            <select
+            <FontPicker
               value={fontFamily}
-              onChange={(e) => setFontFamily(e.target.value)}
-              className="bg-transparent text-xs text-white/90 border border-white/10 rounded px-1.5 py-0.5 focus:outline-none focus:border-white/30 appearance-none cursor-pointer"
-            >
-              {["Inter", "Arial", "Courier New", "Georgia"].map((f) => (
-                <option key={f} value={f} className="bg-gray-800 text-white">
-                  {f}
-                </option>
-              ))}
-            </select>
+              onChange={setFontFamily}
+              selectClassName="text-xs px-1.5 py-0.5"
+              optionClassName="bg-gray-800 text-white"
+            />
           </div>
 
           <div className="flex items-center gap-2 bg-white/5 rounded-lg px-2 py-1">

--- a/frontend/src/components/settings/primitives.tsx
+++ b/frontend/src/components/settings/primitives.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { FolderOpen, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
+import {
+  FolderOpen,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+} from "lucide-react";
 
 export function SectionHeader({
   title,

--- a/frontend/src/lib/customFonts.tsx
+++ b/frontend/src/lib/customFonts.tsx
@@ -1,0 +1,331 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export const BUILTIN_FONTS = ["Inter", "Arial", "Courier New", "Georgia"];
+
+const SUPPORTED_EXTS = [".ttf", ".otf", ".woff", ".woff2"];
+
+const FONT_MIME_TYPES = [
+  "font/ttf",
+  "font/otf",
+  "font/woff",
+  "font/woff2",
+  "application/font-sfnt",
+  "application/x-font-ttf",
+  "application/x-font-otf",
+  "application/vnd.ms-fontobject",
+];
+
+const ACCEPT_EXTENSIONS = [...SUPPORTED_EXTS, ...FONT_MIME_TYPES].join(",");
+
+export interface CustomFont {
+  id: string;
+  name: string;
+  filename: string;
+  ext: string;
+  loaded: boolean;
+}
+
+interface StoredFont {
+  id: string;
+  name: string;
+  filename: string;
+  ext: string;
+  data: ArrayBuffer;
+}
+
+const DB_NAME = "glowsnap-custom-fonts";
+const DB_VERSION = 1;
+const STORE = "fonts";
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: "id" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error("IndexedDB open blocked"));
+  });
+}
+
+function idbPut(record: StoredFont): Promise<void> {
+  return new Promise((resolve, reject) => {
+    openDB()
+      .then((db) => {
+        const tx = db.transaction(STORE, "readwrite");
+        tx.objectStore(STORE).put(record);
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+      })
+      .catch(reject);
+  });
+}
+
+function idbGetAll(): Promise<StoredFont[]> {
+  return new Promise((resolve, reject) => {
+    openDB()
+      .then((db) => {
+        const tx = db.transaction(STORE, "readonly");
+        const req = tx.objectStore(STORE).getAll();
+        req.onsuccess = () => {
+          db.close();
+          resolve((req.result as StoredFont[]) || []);
+        };
+        req.onerror = () => {
+          db.close();
+          reject(req.error);
+        };
+      })
+      .catch(reject);
+  });
+}
+
+function idbDelete(id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    openDB()
+      .then((db) => {
+        const tx = db.transaction(STORE, "readwrite");
+        tx.objectStore(STORE).delete(id);
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+      })
+      .catch(reject);
+  });
+}
+
+export function familyFromFilename(filename: string): string {
+  const base = filename.replace(/\.[^.]+$/, "").trim();
+  return base.length > 0 ? base : filename;
+}
+
+function isValidFontSignature(data: ArrayBuffer, ext: string): boolean {
+  const bytes = new Uint8Array(data);
+  if (bytes.length < 4) return false;
+  const tag =
+    String.fromCharCode(bytes[0]) +
+    String.fromCharCode(bytes[1]) +
+    String.fromCharCode(bytes[2]) +
+    String.fromCharCode(bytes[3]);
+
+  switch (ext) {
+    case ".woff":
+      return tag === "wOFF";
+    case ".woff2":
+      return tag === "wOF2";
+    case ".otf":
+      return (
+        tag === "OTTO" ||
+        tag === "\x00\x01\x00\x00" ||
+        tag === "true" ||
+        tag === "ttcf"
+      );
+    case ".ttf":
+      return tag === "\x00\x01\x00\x00" || tag === "true" || tag === "ttcf";
+    default:
+      return false;
+  }
+}
+
+function generateId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+interface CustomFontsContextValue {
+  fonts: string[];
+  builtinFonts: string[];
+  customFonts: CustomFont[];
+  addFont: (file: File) => Promise<CustomFont>;
+  removeFont: (id: string) => Promise<void>;
+  error: string | null;
+  clearError: () => void;
+  acceptExtensions: string;
+}
+
+const CustomFontsContext = createContext<CustomFontsContextValue | null>(null);
+
+export function CustomFontsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [customFonts, setCustomFonts] = useState<CustomFont[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const loadedFaces = useRef<Map<string, FontFace>>(new Map());
+  const customFontsRef = useRef<CustomFont[]>([]);
+  customFontsRef.current = customFonts;
+
+  const registerFace = useCallback(
+    async (stored: StoredFont): Promise<CustomFont> => {
+      const family = stored.name || familyFromFilename(stored.filename);
+      let loaded = false;
+      try {
+        const face = new FontFace(family, stored.data);
+        await face.load();
+        document.fonts.add(face);
+        loadedFaces.current.set(stored.id, face);
+        loaded = true;
+      } catch {
+        loadedFaces.current.delete(stored.id);
+      }
+      return {
+        id: stored.id,
+        name: family,
+        filename: stored.filename,
+        ext: stored.ext,
+        loaded,
+      };
+    },
+    [],
+  );
+
+  const buildList = useCallback(async () => {
+    try {
+      const all = await idbGetAll();
+      const items: CustomFont[] = [];
+      for (const stored of all) {
+        if (!loadedFaces.current.has(stored.id)) {
+          items.push(await registerFace(stored));
+        } else {
+          items.push({
+            id: stored.id,
+            name: stored.name || familyFromFilename(stored.filename),
+            filename: stored.filename,
+            ext: stored.ext,
+            loaded: true,
+          });
+        }
+      }
+      setCustomFonts(items);
+    } catch (err) {
+      console.error("Failed to load custom fonts:", err);
+    }
+  }, [registerFace]);
+
+  useEffect(() => {
+    buildList().catch(() => {});
+  }, [buildList]);
+
+  const addFont = useCallback(
+    async (file: File): Promise<CustomFont> => {
+      const lower = file.name.toLowerCase();
+      const extMatch = SUPPORTED_EXTS.find((e) => lower.endsWith(e));
+      if (!extMatch) {
+        const msg = `Unsupported font file "${file.name}". Use .ttf, .otf, .woff, or .woff2.`;
+        setError(msg);
+        throw new Error(msg);
+      }
+      const data = await file.arrayBuffer();
+
+      if (!isValidFontSignature(data, extMatch)) {
+        const msg = `"${file.name}" doesn't look like a valid ${extMatch} font file. Please choose an actual font file.`;
+        setError(msg);
+        throw new Error(msg);
+      }
+
+      const family = familyFromFilename(file.name);
+
+      const existing = customFontsRef.current.find(
+        (c) => c.name.toLowerCase() === family.toLowerCase(),
+      );
+      if (existing) {
+        const msg = `Font "${family}" is already available as a custom font.`;
+        setError(msg);
+        throw new Error(msg);
+      }
+
+      const stored: StoredFont = {
+        id: generateId(),
+        name: family,
+        filename: file.name,
+        ext: extMatch,
+        data,
+      };
+      await idbPut(stored);
+      const item = await registerFace(stored);
+      setCustomFonts((prev) => [...prev, item]);
+      setError(null);
+      return item;
+    },
+    [registerFace],
+  );
+
+  const removeFont = useCallback(async (id: string) => {
+    await idbDelete(id);
+    const face = loadedFaces.current.get(id);
+    if (face) {
+      try {
+        document.fonts.delete(face);
+      } catch {
+        // ignore
+      }
+      loadedFaces.current.delete(id);
+    }
+    setCustomFonts((prev) => prev.filter((c) => c.id !== id));
+    setError(null);
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const fonts = useMemo(
+    () => [...BUILTIN_FONTS, ...customFonts.map((c) => c.name)],
+    [customFonts],
+  );
+
+  const value = useMemo<CustomFontsContextValue>(
+    () => ({
+      fonts,
+      builtinFonts: [...BUILTIN_FONTS],
+      customFonts,
+      addFont,
+      removeFont,
+      error,
+      clearError,
+      acceptExtensions: ACCEPT_EXTENSIONS,
+    }),
+    [fonts, customFonts, addFont, removeFont, error, clearError],
+  );
+
+  return (
+    <CustomFontsContext.Provider value={value}>
+      {children}
+    </CustomFontsContext.Provider>
+  );
+}
+
+export function useCustomFonts(): CustomFontsContextValue {
+  const ctx = useContext(CustomFontsContext);
+  if (!ctx) {
+    throw new Error("useCustomFonts must be used within a CustomFontsProvider");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## What changed
- Added support for custom fonts in the Text tool: users can upload their own font files (`.ttf`, `.otf`, `.woff`, `.woff2`) via a new `FontPicker` component, in addition to the existing built-in fonts (Inter, Arial, Courier New, Georgia).
- Added a `CustomFontsProvider` / `useCustomFonts()` context that:
  - Persists uploaded fonts in IndexedDB so they survive across sessions.
  - Registers each font with the browser's `FontFaceSet` (`document.fonts`) on load so it can be used immediately.
  - Exposes `addFont`, `removeFont`, and the combined list of built-in + custom fonts to the UI.
- `FontPicker` renders a `<select>` grouping built-in fonts and a "Custom Fonts" group, plus a small menu to upload a new font or remove existing ones, with inline success/error messaging.
- Custom font names are taken from the uploaded file's name (minus extension), so the name shown in the picker matches what the user uploaded.
- Added a binary signature check (`isValidFontSignature`) that verifies an uploaded file's magic bytes actually match its claimed extension before accepting it, so a renamed/spoofed non-font file (e.g. selected via "All Files") is rejected with a clear error instead of silently corrupting the font list.
- Added explicit font MIME types alongside extensions in the file input's `accept` attribute to fix the type filter defaulting to "All Files" in Linux (GTK) file dialogs.
- If a font fails to load (e.g. previously stored but no longer valid), it's still listed but marked "(unavailable)" instead of being silently dropped.
- Removing the currently selected custom font resets the picker's selection.

## Why it changed
- Users want to use their own fonts (brand fonts, custom lettering, etc.) in the Text tool rather than being limited to the built-in set.
- Fonts need to persist across sessions without a backend, so IndexedDB was used for local storage.
- The file picker's `accept` filter is only a UI hint and can be bypassed, so content-based validation was needed to prevent bad/non-font files from being stored and breaking the picker.
- Naming fonts after the uploaded filename (rather than parsing internal font metadata) is more predictable — it matches what the user actually named their file rather than potentially unrelated internal font metadata.

## How it was tested
- Manual testing in the app (Wails dev build) on Linux:
  - Uploaded `.ttf`, `.otf`, `.woff` files and confirmed they appear correctly in the "Custom Fonts" group and render properly on canvas text.
  - Confirmed the font filter now shows/applies correctly in the Linux file dialog (previously defaulted to "All Files").
  - Verified duplicate uploads (same family name) are rejected with an error message.
  - Attempted to upload a renamed non-font file (e.g. `.txt` renamed to `.ttf`) via "All Files" and confirmed it's rejected.
  - Removed a custom font and confirmed it's unregistered from `document.fonts`, deleted from IndexedDB, and cleared from the selection if it was active.
  - Reloaded the app and confirmed previously uploaded fonts persist and reload correctly.
- `npm run build` — no TypeScript errors.

## Screenshots
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/0390af15-b21f-4d7a-8ea7-6919f696c510" />


## Notes
- WOFF2 files are accepted and loaded via the browser's native `FontFace` API, but their internal metadata is not parsed (not needed now since naming comes from the filename).
- Custom fonts are stored per-browser (IndexedDB), not synced across devices — worth noting if cross-device font sync is expected later.
- Follow-up idea: add a size limit / warning for very large font files, since there's currently no cap on upload size.

---
## Checklist
- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [x] Screenshots added for UI changes