### PR TITLE
Bug: resolve Wails Wayland linking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Linux system dependencies
-
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
+        run: ./scripts/install-deps.sh --install
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,22 +11,14 @@ permissions:
 jobs:
   release:
     name: Build and publish release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            patchelf
+        run: ./scripts/install-deps.sh --install
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -46,7 +38,7 @@ jobs:
         working-directory: frontend
 
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
 
       - name: Determine release channel
         id: channel

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -33,9 +33,9 @@ echo "Detected OS: $OS"
 [ -n "$DISTRO" ] && echo "Detected distro: $DISTRO"
 echo
 
-APT_PACKAGES=(build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf)
-DNF_PACKAGES=(gcc-c++ pkgconf-pkg-config glib2-devel gtk3-devel webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel patchelf)
-PACMAN_PACKAGES=(base-devel gtk3 webkit2gtk-4.1 libappindicator-gtk3 librsvg patchelf)
+APT_PACKAGES=(build-essential libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libwayland-dev patchelf)
+DNF_PACKAGES=(gcc-c++ pkgconf-pkg-config glib2-devel gtk3-devel webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel wayland-devel patchelf)
+PACMAN_PACKAGES=(base-devel gtk3 webkit2gtk-4.1 libappindicator-gtk3 librsvg wayland patchelf)
 
 PKGS=()
 INSTALL_CMD=""

--- a/third_party/wails/cmd/wails/internal/dev/dev.go
+++ b/third_party/wails/cmd/wails/internal/dev/dev.go
@@ -194,7 +194,7 @@ func killProcessAndCleanupBinary(process *process.Process, binary string) error 
 }
 
 func runCommand(dir string, exitOnError bool, command string, args ...string) error {
-	logutils.LogGreen("%s", "Executing: " + command + " " + strings.Join(args, " "))
+	logutils.LogGreen("%s", "Executing: "+command+" "+strings.Join(args, " "))
 	cmd := exec.Command(command, args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
@@ -280,7 +280,7 @@ func restartApp(buildOptions *build.Options, debugBinaryProcess *process.Process
 	appBinary, err := build.Build(buildOptions)
 	println()
 	if err != nil {
-		logutils.LogRed("%s", "Build error - " + err.Error())
+		logutils.LogRed("%s", "Build error - "+err.Error())
 
 		msg := "Continuing to run current version"
 		if debugBinaryProcess == nil {
@@ -321,7 +321,7 @@ func restartApp(buildOptions *build.Options, debugBinaryProcess *process.Process
 		if fs.FileExists(appBinary) {
 			deleteError := fs.DeleteFile(appBinary)
 			if deleteError != nil {
-				buildOptions.Logger.Fatal("%s", "Unable to delete app binary: " + appBinary)
+				buildOptions.Logger.Fatal("%s", "Unable to delete app binary: "+appBinary)
 			}
 		}
 		buildOptions.Logger.Fatal("Unable to start application: %s", err.Error())

--- a/third_party/wails/internal/binding/binding.go
+++ b/third_party/wails/internal/binding/binding.go
@@ -59,7 +59,7 @@ func NewBindings(logger *logger.Logger, structPointersToBind []interface{}, exem
 	for _, ptr := range structPointersToBind {
 		err := result.Add(ptr)
 		if err != nil {
-			logger.Fatal("%s", "Error during binding: " + err.Error())
+			logger.Fatal("%s", "Error during binding: "+err.Error())
 		}
 	}
 

--- a/third_party/wails/internal/binding/binding_test/binding_enum_ordering_test.go
+++ b/third_party/wails/internal/binding/binding_test/binding_enum_ordering_test.go
@@ -52,10 +52,10 @@ var AllMMiddleEnumValues = []struct {
 }
 
 type EntityWithMultipleEnums struct {
-	Name   string      `json:"name"`
-	EnumZ  ZFirstEnum  `json:"enumZ"`
-	EnumA  ASecondEnum `json:"enumA"`
-	EnumM  MMiddleEnum `json:"enumM"`
+	Name  string      `json:"name"`
+	EnumZ ZFirstEnum  `json:"enumZ"`
+	EnumA ASecondEnum `json:"enumA"`
+	EnumM MMiddleEnum `json:"enumM"`
 }
 
 func (e EntityWithMultipleEnums) Get() EntityWithMultipleEnums {

--- a/third_party/wails/internal/frontend/desktop/linux/keys.go
+++ b/third_party/wails/internal/frontend/desktop/linux/keys.go
@@ -4,7 +4,7 @@
 package linux
 
 /*
-#cgo linux pkg-config: gtk+-3.0 
+#cgo linux pkg-config: gtk+-3.0
 #cgo !webkit2_41 pkg-config: webkit2gtk-4.0
 #cgo webkit2_41 pkg-config: webkit2gtk-4.1
 

--- a/third_party/wails/internal/frontend/desktop/linux/screen.go
+++ b/third_party/wails/internal/frontend/desktop/linux/screen.go
@@ -4,7 +4,7 @@
 package linux
 
 /*
-#cgo linux pkg-config: gtk+-3.0 
+#cgo linux pkg-config: gtk+-3.0
 #cgo !webkit2_41 pkg-config: webkit2gtk-4.0
 #cgo webkit2_41 pkg-config: webkit2gtk-4.1
 

--- a/third_party/wails/internal/frontend/desktop/linux/window.c
+++ b/third_party/wails/internal/frontend/desktop/linux/window.c
@@ -890,93 +890,10 @@ void InstallF12Hotkey(void *window)
     gtk_accel_group_connect(accel_group, GDK_KEY_F12, GDK_CONTROL_MASK | GDK_SHIFT_MASK, GTK_ACCEL_VISIBLE, closure);
 }
 
-typedef struct WailsWaylandDecoration
-{
-    struct wl_display *display;
-    struct zxdg_decoration_manager_v1 *manager;
-    struct xdg_toplevel *toplevel;
-    struct zxdg_toplevel_decoration_v1 *decoration;
-} WailsWaylandDecoration;
-
-typedef struct WailsDecorationBind
-{
-    struct zxdg_decoration_manager_v1 *manager;
-} WailsDecorationBind;
-
-static void decorationHandleGlobal(void *data, struct wl_registry *registry,
-                                   uint32_t name, const char *interface,
-                                   uint32_t version)
-{
-    WailsDecorationBind *bind = data;
-    if (bind->manager == NULL && strcmp(interface, "zxdg_decoration_manager_v1") == 0)
-    {
-        uint32_t bindVersion = version < 2 ? version : 2;
-        bind->manager = wl_registry_bind(registry, name, &zxdg_decoration_manager_v1_interface, bindVersion);
-    }
-}
-
-static void decorationHandleRemove(void *data, struct wl_registry *registry,
-                                   uint32_t name)
-{
-}
-
-static const struct wl_registry_listener decorationRegistryListener = {
-    decorationHandleGlobal,
-    decorationHandleRemove,
-};
-
-static void decorationHandleConfigure(void *data, struct zxdg_toplevel_decoration_v1 *decoration,
-                                      uint32_t mode)
-{
-}
-
-static const struct zxdg_toplevel_decoration_v1_listener decorationListener = {
-    decorationHandleConfigure,
-};
-
-static struct zxdg_decoration_manager_v1 *decorationBindManager(GdkDisplay *display)
-{
-    struct wl_display *wlDisplay;
-    struct wl_registry *registry;
-    WailsDecorationBind *bind;
-    struct zxdg_decoration_manager_v1 *manager;
-
-    wlDisplay = gdk_wayland_display_get_wl_display(display);
-    if (wlDisplay == NULL)
-    {
-        return NULL;
-    }
-
-    bind = g_new0(WailsDecorationBind, 1);
-    registry = wl_display_get_registry(wlDisplay);
-    if (registry == NULL)
-    {
-        g_free(bind);
-        return NULL;
-    }
-
-    wl_registry_add_listener(registry, &decorationRegistryListener, bind);
-    wl_display_roundtrip(wlDisplay);
-    wl_registry_destroy(registry);
-
-    manager = bind->manager;
-    g_free(bind);
-
-    return manager;
-}
-
 static void decorationReconcile(GtkWindow *window)
 {
-    WailsWaylandDecoration *dec;
     GdkWindow *gdkWindow;
     GdkDisplay *display;
-    struct xdg_toplevel *toplevel;
-
-    dec = g_object_get_data(G_OBJECT(window), "wails-wayland-decoration");
-    if (dec == NULL)
-    {
-        return;
-    }
 
     gdkWindow = gtk_widget_get_window(GTK_WIDGET(window));
     if (gdkWindow == NULL)
@@ -990,52 +907,14 @@ static void decorationReconcile(GtkWindow *window)
         return;
     }
 
-    toplevel = gdk_wayland_window_get_xdg_toplevel(gdkWindow);
-    if (toplevel == NULL)
-    {
-        return;
-    }
-
-    if (toplevel == dec->toplevel && dec->decoration != NULL)
-    {
-        return;
-    }
-
-    if (dec->decoration != NULL)
-    {
-        wl_proxy_destroy((struct wl_proxy *)dec->decoration);
-        dec->decoration = NULL;
-    }
-    dec->toplevel = toplevel;
-
-    if (dec->manager == NULL)
-    {
-        dec->manager = decorationBindManager(display);
-        if (dec->manager == NULL)
-        {
-            return;
-        }
-        dec->display = gdk_wayland_display_get_wl_display(display);
-    }
-
-    if (zxdg_decoration_manager_v1_get_version(dec->manager) < 2)
-    {
-        return;
-    }
-
-    dec->decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(dec->manager, toplevel);
-    if (dec->decoration == NULL)
-    {
-        return;
-    }
-
-    zxdg_toplevel_decoration_v1_add_listener(dec->decoration, &decorationListener, window);
-    zxdg_toplevel_decoration_v1_set_mode(dec->decoration, ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE);
-
-    if (dec->display != NULL)
-    {
-        wl_display_flush(dec->display);
-    }
+    // Request client-side decorations from the Wayland compositor (e.g. KDE
+    // Plasma on Wayland) so the frameless window is not given a server-side
+    // title bar. GDK's exported gdk_wayland_window_announce_csd() API is
+    // present on both Ubuntu and Fedora GTK3 builds, unlike the internal
+    // gdk_wayland_window_get_xdg_toplevel() symbol which Ubuntu's GTK3 does
+    // not ship (causing the CI link failure). It is the portable form of the
+    // KDE/Wayland window decoration fix.
+    gdk_wayland_window_announce_csd(gdkWindow);
 }
 
 static void decorationOnMap(GtkWidget *widget, gpointer data)
@@ -1043,29 +922,9 @@ static void decorationOnMap(GtkWidget *widget, gpointer data)
     decorationReconcile(GTK_WINDOW(widget));
 }
 
-static void decorationCleanup(GtkWidget *widget, gpointer data)
-{
-    WailsWaylandDecoration *dec = g_object_get_data(G_OBJECT(widget), "wails-wayland-decoration");
-    if (dec == NULL)
-    {
-        return;
-    }
-    if (dec->decoration != NULL)
-    {
-        wl_proxy_destroy((struct wl_proxy *)dec->decoration);
-    }
-    if (dec->manager != NULL)
-    {
-        wl_proxy_destroy((struct wl_proxy *)dec->manager);
-    }
-    g_object_set_data(G_OBJECT(widget), "wails-wayland-decoration", NULL);
-    g_free(dec);
-}
-
 void SetWindowFrameless(GtkWindow *window)
 {
     GdkDisplay *display;
-    WailsWaylandDecoration *dec;
 
     if (!GTK_IS_WINDOW(window))
     {
@@ -1083,10 +942,8 @@ void SetWindowFrameless(GtkWindow *window)
         return;
     }
 
-    dec = g_new0(WailsWaylandDecoration, 1);
-    g_object_set_data(G_OBJECT(window), "wails-wayland-decoration", dec);
+    g_object_set_data(G_OBJECT(window), "wails-wayland-decoration", GUINT_TO_POINTER(1));
     g_signal_connect(window, "map", G_CALLBACK(decorationOnMap), NULL);
-    g_signal_connect(window, "destroy", G_CALLBACK(decorationCleanup), NULL);
 
     decorationReconcile(window);
 }

--- a/third_party/wails/internal/frontend/desktop/windows/frontend.go
+++ b/third_party/wails/internal/frontend/desktop/windows/frontend.go
@@ -73,9 +73,9 @@ type Frontend struct {
 
 	// Pending JS callbacks are batched to avoid saturating WebView2's
 	// ExecuteScript queue under heavy concurrent Go->JS call load.
-	callbackMu      sync.Mutex
+	callbackMu       sync.Mutex
 	pendingCallbacks []string
-	drainScheduled  bool
+	drainScheduled   bool
 }
 
 func NewFrontend(ctx context.Context, appoptions *options.App, myLogger *logger.Logger, appBindings *binding.Bindings, dispatcher frontend.Dispatcher) *Frontend {

--- a/third_party/wails/internal/go-common-file-dialog/cfd/errors.go
+++ b/third_party/wails/internal/go-common-file-dialog/cfd/errors.go
@@ -3,7 +3,7 @@ package cfd
 import "errors"
 
 var (
-	ErrCancelled = errors.New("cancelled by user")
-	ErrInvalidGUID = errors.New("guid cannot be nil")
+	ErrCancelled    = errors.New("cancelled by user")
+	ErrInvalidGUID  = errors.New("guid cannot be nil")
 	ErrEmptyFilters = errors.New("must specify at least one filter")
 )

--- a/third_party/wails/pkg/assetserver/webview/webkit2_36+.go
+++ b/third_party/wails/pkg/assetserver/webview/webkit2_36+.go
@@ -1,9 +1,9 @@
-//go:build linux && (webkit2_36 || webkit2_40 || webkit2_41 )
+//go:build linux && (webkit2_36 || webkit2_40 || webkit2_41)
 
 package webview
 
 /*
-#cgo linux pkg-config: gtk+-3.0 
+#cgo linux pkg-config: gtk+-3.0
 #cgo !webkit2_41 pkg-config: webkit2gtk-4.0 libsoup-2.4
 #cgo webkit2_41 pkg-config: webkit2gtk-4.1 libsoup-3.0
 

--- a/third_party/wails/pkg/clilogger/clilogger.go
+++ b/third_party/wails/pkg/clilogger/clilogger.go
@@ -34,7 +34,7 @@ func (c *CLILogger) Print(message string, args ...interface{}) {
 
 	_, err := fmt.Fprintf(c.Writer, message, args...)
 	if err != nil {
-		c.Fatal("%s", "FATAL: " + err.Error())
+		c.Fatal("%s", "FATAL: "+err.Error())
 	}
 }
 
@@ -46,7 +46,7 @@ func (c *CLILogger) Println(message string, args ...interface{}) {
 	temp := fmt.Sprintf(message, args...)
 	_, err := fmt.Fprintln(c.Writer, temp)
 	if err != nil {
-		c.Fatal("%s", "FATAL: " + err.Error())
+		c.Fatal("%s", "FATAL: "+err.Error())
 	}
 }
 


### PR DESCRIPTION
## What changed

- Fixed the Linux/Wails release build failing with an undefined reference to `gdk_wayland_window_get_xdg_toplevel`.
- Updated the patched Wails Wayland decoration handling to use GDK's portable client-side-decoration API via `gdk_wayland_window_announce_csd()`.
- Pinned GitHub Actions to `ubuntu-24.04` for a stable GTK/WebKitGTK build environment.
- Pinned the Wails CLI to `v2.13.0` to match the project's patched Wails version.
- Added `libwayland-dev` to the Linux build dependencies.
- Kept the existing KDE/Wayland frameless-window behavior and `webkit2_41` build configuration unchanged.

## Why it changed

The release build was failing during the Linux linker stage because `gdk_wayland_window_get_xdg_toplevel` is not available in the Ubuntu CI environment.

The existing KDE/Wayland patch relied on that symbol for frameless window decoration. Replacing that path with GDK's client-side-decoration API removes the unavailable symbol while preserving the intended KDE behavior.

The Wails CLI was also using `v2.14.0` while the project uses the patched `v2.13.0`, so the CLI was pinned to the matching version.

## How it was tested

- `pkg-config --modversion gtk+-3.0 webkit2gtk-4.1`
- `go list -m github.com/wailsapp/wails/v2`
- `go list -m -f "{{.Dir}}" github.com/wailsapp/wails/v2`
- `./scripts/install-deps.sh --install`
- `./scripts/release.sh v0.0.1_test beta`
- `go vet -tags webkit2_41 ./...`
- `wails doctor`
- Verified the resulting binary and Wails dependency resolution.
- Push test tag on my fork


## Screenshots
None

## Notes

- The existing local Wails/KDE patch is preserved.
- `webkit2_41` remains enabled.
- WebKitGTK was not downgraded.
- No unrelated application or frontend code was changed.
- GitHub Actions now uses a stable Ubuntu 24.04 baseline for the Linux release build.

---

## Checklist

- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [ ] Screenshots added for UI changes