### PR TITLE
Add docker & .prettierignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Git / VCS metadata
+.git
+
+# Frontend: node_modules and generated dist are produced inside the build
+frontend/node_modules
+frontend/dist
+
+# Go build outputs
+build/bin
+build/AppImage
+
+# AppImage tooling and artifacts (root-level appimagetool binary, built outputs)
+appimagetool-*.AppImage
+*.AppImage
+glowsnap.AppDir
+AppDir/
+squashfs-root/
+
+# Local release artifacts
+release/
+
+# NOTE: third_party/ is intentionally NOT excluded here. go.mod uses a local
+# `replace github.com/wailsapp/wails/v2 => ./third_party/wails` directive, so
+# those sources must remain in the Docker build context.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ build/bin
 node_modules
 frontend/dist
 
+out/
+
 AppDir/
 *.AppImage
 squashfs-root/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+wailsjs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,99 @@
+# syntax=docker/dockerfile:1
+
+# ============================================================================
+# GlowSnap — reproducible Linux build container (Wails v2 desktop app)
+#
+# Produces ONLY the compiled `glowsnap` binary. This container is strictly for
+# building and testing. It does NOT run the GUI and does not forward X11,
+# Wayland, DBus, or audio into the container.
+#
+# Stages:
+#   frontend  (dependency, not a target)  - builds the React/TS UI into dist/
+#   builder   (default target)            - runs tests + compiles the Go/Wails binary
+#   artifacts (--target artifacts)        - scratch image exporting just the binary
+#
+# Requires BuildKit (the modern Docker default; enable via DOCKER_BUILDKIT=1
+# if you are on an old Docker that does not enable it automatically).
+#
+# Usage:
+#   docker build -t glowsnap:build .                                   # build + test
+#   docker build --target artifacts -o out/ .                          # export binary
+#   docker run --rm glowsnap:build go test -tags webkit2_41 ./...      # run tests
+#
+# NOTE: The produced binary is a REPRODUCIBLE Linux build, but it is NOT a
+# universally portable binary across Linux distributions. GlowSnap links
+# dynamically against GTK/WebKitGTK and other system libraries that must be
+# present on the target machine at runtime.
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage frontend : build the embedded web assets (Node 22 / Debian Bookworm).
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm AS frontend
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching. The BuildKit cache mount
+# on the npm cache avoids re-downloading packages across repeated builds.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+# Copy the remaining frontend sources (including the committed Wails bindings
+# under frontend/wailsjs) and produce the embedded `dist/` bundle.
+COPY frontend/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage builder : compile the Go/Wails backend and run the test suite.
+# ---------------------------------------------------------------------------
+FROM golang:1.25-bookworm AS builder
+
+ARG VERSION=dev
+ENV CGO_ENABLED=1
+
+# Native libraries required to link the Wails/WebKitGTK 4.1 bindings.
+# This mirrors the Debian/Ubuntu package list in scripts/install-deps.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libgtk-3-dev \
+        libwebkit2gtk-4.1-dev \
+        libayatana-appindicator3-dev \
+        librsvg2-dev \
+        libwayland-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy the module manifests AND the locally-replaced Wails module before
+# `go mod download` so the dependency layer is cached until these change.
+# third_party/ is required: go.mod uses `replace github.com/wailsapp/wails/v2
+# => ./third_party/wails`, so its contents must be present for module
+# resolution and compilation. The BuildKit cache mount keeps the module cache
+# between builds.
+COPY go.mod go.sum ./
+COPY third_party/ ./third_party/
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+# Place the freshly built frontend bundle where the //go:embed all:frontend/dist
+# directive expects it.
+COPY --from=frontend /app/dist ./frontend/dist
+
+# Copy the Go sources (root packages + services) and the embedded icon.
+COPY *.go ./
+COPY services/ ./services/
+COPY build/appicon.png ./build/appicon.png
+
+# Run the project test suite exactly as CI does.
+RUN go test -tags webkit2_41 ./...
+
+# Compile the production binary with the pinned version injection.
+RUN go build -tags webkit2_41 -trimpath \
+        -ldflags "-X main.appVersion=$VERSION" \
+        -o build/bin/glowsnap .
+
+# ---------------------------------------------------------------------------
+# Stage artifacts : export ONLY the compiled binary, for --target artifacts.
+# ---------------------------------------------------------------------------
+FROM scratch AS artifacts
+COPY --from=builder /build/build/bin/glowsnap /glowsnap

--- a/README.md
+++ b/README.md
@@ -78,6 +78,65 @@ Coming soon on Flathub
 
 ---
 
+## Building with Docker
+
+GlowSnap ships a [multi-stage `Dockerfile`](./Dockerfile) that provides a fully
+reproducible Linux build environment. It installs the native toolchain (Go,
+Node, Wails/WebKitGTK 4.1 system libraries) inside an isolated container, builds
+the frontend, runs the test suite, and compiles the final binary.
+
+This container is **strictly for building and testing** — it does not run the
+GUI and does not forward X11/Wayland, DBus, or audio.
+
+> **Prerequisite:** the build uses BuildKit, which is enabled by default in
+> modern Docker. On older Docker versions set `DOCKER_BUILDKIT=1`.
+
+### Build the binary (and run the tests)
+
+The tests run as part of the build. The default final stage (`artifacts`) is a
+minimal image containing only the compiled binary at `/glowsnap`:
+
+```bash
+docker build -t glowsnap:build .
+```
+
+### Export only the binary
+
+Explicitly target the `artifacts` stage and write the binary to `./out`:
+
+```bash
+docker build --target artifacts -o out/ .
+./out/glowsnap --version
+```
+
+### Run the test suite inside the container
+
+Tag the runnable `builder` stage (it contains the Go toolchain and source, and
+its working directory is `/build`), then run the tests exactly as CI does:
+
+```bash
+docker build --target builder -t glowsnap:builder .
+docker run --rm glowsnap:builder go test -tags webkit2_41 ./...
+```
+
+### Build with a custom version string
+
+The injected version defaults to `dev`. Pass a release version with an `ARG`:
+
+```bash
+docker build --build-arg VERSION=1.1.0 -t glowsnap:build .
+```
+
+### Portability note
+
+The resulting binary is a **reproducible Linux build**, but it is **not a
+universally portable binary across all Linux distributions**. GlowSnap links
+dynamically against GTK/WebKitGTK and other system libraries that must be
+present on the target machine at runtime. For a self-contained, distribution
+independent artifact, use the AppImage packaging (see `scripts/build-appimage.sh`).
+
+---
+
 ## Built With
 
 - **Go** — Backend and native system integration


### PR DESCRIPTION
## What changed

Added a multi-stage Docker build setup for GlowSnap.

* Added a `Dockerfile` for reproducible Linux builds.
* Added `.dockerignore` to keep the Docker build context small.
* Added Docker build instructions to the documentation.
* The container builds the React frontend, installs the required GTK/WebKitGTK dependencies, runs the Go test suite, and produces the GlowSnap binary.
* The Docker setup does not run the GUI or require X11/Wayland, DBus, or audio forwarding.
* Add .prettierignore

## Why it changed

Provides a reproducible, isolated build environment that matches the project's CI toolchain and dependencies, making it easier to build and test GlowSnap consistently across development environments.

## How it was tested

Validated locally with Docker:

```bash
docker build -t glowsnap:build .
```

The build completed successfully, including:

```bash
go test -tags webkit2_41 ./...
go build -tags webkit2_41 ...
```

The binary was also successfully exported using:

```bash
docker build --target artifacts -o out .
```

and produced:

```text
out/glowsnap
```

## Screenshots

Not applicable — this is a build/tooling change with no UI changes.

## Notes

The Docker setup is intended for reproducible building and testing only. It does not run the GlowSnap GUI inside the container.

The resulting binary is a Linux build that still requires the appropriate GTK/WebKitGTK system libraries at runtime.

---

## Checklist

* [x] Tests pass (or no tests are affected)
* [ ] Documentation updated if needed
* [x] Code is formatted and lint-clean
* [x] No unnecessary dependencies added
* [x] Breaking changes (if any) are called out in the Notes
* [ ] Screenshots added for UI changes
