### PR TITLE
Add favorites to record studio

### DIFF
--- a/frontend/src/components/Record.tsx
+++ b/frontend/src/components/Record.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { ArrowLeft, RefreshCw, Film, Search } from "lucide-react";
+import { ArrowLeft, RefreshCw, Film, Search, Star } from "lucide-react";
 import { RecordProps, Recording } from "@/types/types";
 import {
   ListRecordings,
   GetRecordingsBaseURL,
+  GetSettings,
+  UpdateSettings,
 } from "../../wailsjs/go/main/App";
+import { settings } from "../../wailsjs/go/models";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 function useDebounce<T>(value: T, delay: number): T {
@@ -16,17 +19,62 @@ function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
-export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProps) {
+export default function Record({
+  onBackToPalette,
+  onSwitchToStudio,
+}: RecordProps) {
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [baseUrl, setBaseUrl] = useState("");
   const [loading, setLoading] = useState(true);
-  const [selectedRecording, setSelectedRecording] = useState<Recording | null>(null);
+  const [selectedRecording, setSelectedRecording] = useState<Recording | null>(
+    null,
+  );
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, 300);
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest" | "az" | "za">(
     "newest",
   );
+  const [favorites, setFavorites] = useState<Set<string>>(new Set());
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const cfg = await GetSettings();
+        if (!active) return;
+        setFavorites(new Set(cfg.favorites?.recordings ?? []));
+      } catch {
+        if (active) setFavorites(new Set());
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const toggleFavorite = async (fileName: string) => {
+    setFavorites((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(fileName)) newSet.delete(fileName);
+      else newSet.add(fileName);
+      return newSet;
+    });
+    try {
+      const cfg = await GetSettings();
+      const favs = new Set(cfg.favorites?.recordings ?? []);
+      if (favs.has(fileName)) favs.delete(fileName);
+      else favs.add(fileName);
+      const next = settings.Settings.createFrom({
+        ...cfg,
+        favorites: { ...(cfg.favorites ?? {}), recordings: [...favs] },
+      });
+      await UpdateSettings(next);
+    } catch (err) {
+      console.error("Failed to save favorite:", err);
+    }
+  };
 
   const loadRecordings = async () => {
     try {
@@ -86,12 +134,20 @@ export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProp
       filtered = filtered.filter((r) => r.name.toLowerCase().includes(q));
     }
 
+    if (showFavoritesOnly) {
+      filtered = filtered.filter((r) => favorites.has(r.name));
+    }
+
     switch (sortOrder) {
       case "newest":
-        filtered.sort((a, b) => parseDateFromName(b.name) - parseDateFromName(a.name));
+        filtered.sort(
+          (a, b) => parseDateFromName(b.name) - parseDateFromName(a.name),
+        );
         break;
       case "oldest":
-        filtered.sort((a, b) => parseDateFromName(a.name) - parseDateFromName(b.name));
+        filtered.sort(
+          (a, b) => parseDateFromName(a.name) - parseDateFromName(b.name),
+        );
         break;
       case "az":
         filtered.sort((a, b) => a.name.localeCompare(b.name));
@@ -102,7 +158,7 @@ export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProp
     }
 
     return filtered;
-  }, [recordings, debouncedSearch, sortOrder]);
+  }, [recordings, debouncedSearch, sortOrder, showFavoritesOnly, favorites]);
 
   if (selectedRecording) {
     return (
@@ -161,9 +217,7 @@ export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProp
           >
             Studio
           </button>
-          <button
-            className="px-3 py-1 text-xs rounded-md bg-white/15 text-white font-medium"
-          >
+          <button className="px-3 py-1 text-xs rounded-md bg-white/15 text-white font-medium">
             Record
           </button>
         </div>
@@ -220,6 +274,14 @@ export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProp
           </div>
 
           <button
+            onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+            className={`p-2 rounded-lg ${showFavoritesOnly ? "bg-yellow-500/20 text-yellow-400" : "bg-white/5 text-white/60"} hover:bg-white/10`}
+            title="Show favorites only"
+          >
+            <Star size={14} />
+          </button>
+
+          <button
             onClick={loadRecordings}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium hover:bg-white/10 transition-colors"
           >
@@ -253,18 +315,38 @@ export default function Record({ onBackToPalette, onSwitchToStudio }: RecordProp
             </span>
             <div className="flex flex-col gap-0.5">
               {processedRecordings.map((rec) => (
-                <button
+                <div
                   key={rec.name}
                   onClick={() => handleSelectRecording(rec)}
-                  className="text-left px-3 py-2 rounded-lg text-xs transition-colors text-white/60 hover:bg-white/5 hover:text-white/90"
+                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-xs transition-colors text-white/60 hover:bg-white/5 hover:text-white/90 cursor-pointer group"
                 >
-                  <span className="block truncate">{rec.name}</span>
-                  {formatDate(rec.name) && (
-                    <span className="text-[10px] text-white/30">
-                      {formatDate(rec.name)}
-                    </span>
-                  )}
-                </button>
+                  <div className="min-w-0">
+                    <span className="block truncate">{rec.name}</span>
+                    {formatDate(rec.name) && (
+                      <span className="text-[10px] text-white/30">
+                        {formatDate(rec.name)}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleFavorite(rec.name);
+                    }}
+                    className={`text-xs shrink-0 ${
+                      favorites.has(rec.name)
+                        ? "text-yellow-400"
+                        : "text-white/30 hover:text-yellow-400"
+                    }`}
+                    title={
+                      favorites.has(rec.name)
+                        ? "Remove from favorites"
+                        : "Add to favorites"
+                    }
+                  >
+                    <Star size={15} />
+                  </button>
+                </div>
               ))}
             </div>
           </div>

--- a/frontend/src/components/Studio.tsx
+++ b/frontend/src/components/Studio.tsx
@@ -81,7 +81,10 @@ function dateGroupLabel(unixSeconds: number): string {
   });
 }
 
-export default function Studio({ onBackToPalette, onSwitchToRecord }: StudioProps) {
+export default function Studio({
+  onBackToPalette,
+  onSwitchToRecord,
+}: StudioProps) {
   const [images, setImages] = useState<Screenshot[]>([]);
   const [baseUrl, setBaseUrl] = useState("");
   const [loading, setLoading] = useState(true);
@@ -360,9 +363,7 @@ export default function Studio({ onBackToPalette, onSwitchToRecord }: StudioProp
         </div>
 
         <div className="flex bg-white/5 rounded-lg p-0.5 border border-white/10 ml-auto mr-auto">
-          <button
-            className="px-3 py-1 text-xs rounded-md bg-white/15 text-white font-medium"
-          >
+          <button className="px-3 py-1 text-xs rounded-md bg-white/15 text-white font-medium">
             Studio
           </button>
           <button

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -110,6 +110,20 @@ export namespace settings {
 	        this.defaultOpacity = source["defaultOpacity"];
 	    }
 	}
+	export class Favorites {
+	    recordings: string[];
+	    screenshots: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new Favorites(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.recordings = source["recordings"];
+	        this.screenshots = source["screenshots"];
+	    }
+	}
 	export class General {
 	    confirmDelete: boolean;
 	
@@ -202,6 +216,7 @@ export namespace settings {
 	    advanced: Advanced;
 	    shortcuts: Shortcuts;
 	    customShortcuts: Record<string, string>;
+	    favorites: Favorites;
 	
 	    static createFrom(source: any = {}) {
 	        return new Settings(source);
@@ -216,6 +231,7 @@ export namespace settings {
 	        this.advanced = this.convertValues(source["advanced"], Advanced);
 	        this.shortcuts = this.convertValues(source["shortcuts"], Shortcuts);
 	        this.customShortcuts = source["customShortcuts"];
+	        this.favorites = this.convertValues(source["favorites"], Favorites);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/services/settings/settings.go
+++ b/services/settings/settings.go
@@ -60,6 +60,11 @@ type Shortcuts struct {
 	Cancel         string `json:"cancel"`
 }
 
+type Favorites struct {
+	Recordings  []string `json:"recordings"`
+	Screenshots []string `json:"screenshots"`
+}
+
 type Settings struct {
 	General         General           `json:"general"`
 	Screenshot      Screenshot        `json:"screenshot"`
@@ -68,6 +73,7 @@ type Settings struct {
 	Advanced        Advanced          `json:"advanced"`
 	Shortcuts       Shortcuts         `json:"shortcuts"`
 	CustomShortcuts map[string]string `json:"customShortcuts"`
+	Favorites       Favorites         `json:"favorites"`
 }
 
 type legacySettings struct {
@@ -117,6 +123,10 @@ func Defaults() Settings {
 			DefaultOpacity:     1,
 		},
 		Shortcuts: DefaultShortcuts(),
+		Favorites: Favorites{
+			Recordings:  []string{},
+			Screenshots: []string{},
+		},
 	}
 }
 
@@ -318,6 +328,13 @@ func mergeDefaults(def Settings, stored *Settings, data []byte) {
 		stored.Advanced.VerboseLogging = def.Advanced.VerboseLogging
 	}
 
+	if !present("favorites", "recordings") {
+		stored.Favorites.Recordings = def.Favorites.Recordings
+	}
+	if !present("favorites", "screenshots") {
+		stored.Favorites.Screenshots = def.Favorites.Screenshots
+	}
+
 	if !present("shortcuts", "takeScreenshot") {
 		stored.Shortcuts.TakeScreenshot = def.Shortcuts.TakeScreenshot
 	}
@@ -341,6 +358,12 @@ func mergeDefaults(def Settings, stored *Settings, data []byte) {
 func normalize(s Settings) Settings {
 	if s.CustomShortcuts == nil {
 		s.CustomShortcuts = map[string]string{}
+	}
+	if s.Favorites.Recordings == nil {
+		s.Favorites.Recordings = []string{}
+	}
+	if s.Favorites.Screenshots == nil {
+		s.Favorites.Screenshots = []string{}
 	}
 	for id, combo := range s.CustomShortcuts {
 		s.CustomShortcuts[id] = strings.TrimSpace(combo)


### PR DESCRIPTION
## What changed

I'm add a favorites to the record studio, user can enable/disable fav for video and see it
## Why it changed

user can distinguish one video from another.

## How it was tested

run `wails dev`

## Screenshots

<img width="1920" height="1080" alt="Screenshot From 2026-08-23 13-32-44" src="https://github.com/user-attachments/assets/30c5295d-8a0d-4682-93f9-81d2304fddb7" />
<img width="1920" height="1044" alt="Screenshot From 2026-08-23 13-32-53" src="https://github.com/user-attachments/assets/13d1f3c3-9098-41a3-995f-e241e30fdbd2" />


## Notes

Nothing

---

## Checklist

- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [x] Screenshots added for UI changes
