### PR TITLE
feat: Add delete button to the record studio

### DIFF
--- a/app.go
+++ b/app.go
@@ -571,6 +571,28 @@ func (a *App) DeleteScreenshot(fileName string) error {
 	return os.Remove(path)
 }
 
+func (a *App) DeleteRecording(fileName string) error {
+	dir := settings.Load().RecordingSaveDir()
+	path := filepath.Join(dir, fileName)
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+
+	s := settings.Load()
+	favs := s.Favorites.Recordings
+	var kept []string
+	for _, name := range favs {
+		if name != fileName {
+			kept = append(kept, name)
+		}
+	}
+	if len(kept) != len(favs) {
+		s.Favorites.Recordings = kept
+		return settings.Save(s)
+	}
+	return nil
+}
+
 type RecordingInfo struct {
 	Name string `json:"name"`
 	Path string `json:"path"`

--- a/frontend/src/components/Record.tsx
+++ b/frontend/src/components/Record.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { ArrowLeft, RefreshCw, Film, Search, Star } from "lucide-react";
+import { ArrowLeft, RefreshCw, Film, Search, Star, X } from "lucide-react";
 import { RecordProps, Recording } from "@/types/types";
 import {
   ListRecordings,
   GetRecordingsBaseURL,
   GetSettings,
   UpdateSettings,
+  DeleteRecording,
 } from "../../wailsjs/go/main/App";
 import { settings } from "../../wailsjs/go/models";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -54,26 +55,25 @@ export default function Record({
     };
   }, []);
 
-  const toggleFavorite = async (fileName: string) => {
-    setFavorites((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(fileName)) newSet.delete(fileName);
-      else newSet.add(fileName);
-      return newSet;
-    });
+  const saveRecordingsFavorites = async (names: Set<string>) => {
     try {
       const cfg = await GetSettings();
-      const favs = new Set(cfg.favorites?.recordings ?? []);
-      if (favs.has(fileName)) favs.delete(fileName);
-      else favs.add(fileName);
       const next = settings.Settings.createFrom({
         ...cfg,
-        favorites: { ...(cfg.favorites ?? {}), recordings: [...favs] },
+        favorites: { ...(cfg.favorites ?? {}), recordings: [...names] },
       });
       await UpdateSettings(next);
     } catch (err) {
-      console.error("Failed to save favorite:", err);
+      console.error("Failed to save favorites:", err);
     }
+  };
+
+  const toggleFavorite = (fileName: string) => {
+    const next = new Set(favorites);
+    if (next.has(fileName)) next.delete(fileName);
+    else next.add(fileName);
+    setFavorites(next);
+    void saveRecordingsFavorites(next);
   };
 
   const loadRecordings = async () => {
@@ -93,6 +93,33 @@ export default function Record({
   useEffect(() => {
     loadRecordings();
   }, []);
+
+  const syncRecordings = async () => {
+    try {
+      const files = await ListRecordings();
+      setRecordings(files ?? []);
+    } catch (err) {
+      console.error("Failed to reload recordings:", err);
+    }
+  };
+
+  const handleDelete = async (fileName: string) => {
+    try {
+      const cfg = await GetSettings();
+      const shouldConfirm = cfg.general?.confirmDelete ?? true;
+      if (shouldConfirm && !window.confirm(`Delete ${fileName}?`)) {
+        return;
+      }
+      await DeleteRecording(fileName);
+      const next = new Set(favorites);
+      next.delete(fileName);
+      setFavorites(next);
+      void saveRecordingsFavorites(next);
+      await syncRecordings();
+    } catch (err) {
+      console.error("Failed to delete recording:", err);
+    }
+  };
 
   const handleSelectRecording = (recording: Recording) => {
     setSelectedRecording(recording);
@@ -345,6 +372,16 @@ export default function Record({
                     }
                   >
                     <Star size={15} />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleDelete(rec.name);
+                    }}
+                    className="text-xs shrink-0 text-red-400 hover:text-red-300"
+                    title="Delete recording"
+                  >
+                    <X size={15} />
                   </button>
                 </div>
               ))}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -10,6 +10,8 @@ export function CancelRecording():Promise<void>;
 
 export function CompletePaletteAreaScreenshot(arg1:number,arg2:number,arg3:number,arg4:number):Promise<void>;
 
+export function DeleteRecording(arg1:string):Promise<void>;
+
 export function DeleteScreenshot(arg1:string):Promise<void>;
 
 export function GetAppVersion():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -14,6 +14,10 @@ export function CompletePaletteAreaScreenshot(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['CompletePaletteAreaScreenshot'](arg1, arg2, arg3, arg4);
 }
 
+export function DeleteRecording(arg1) {
+  return window['go']['main']['App']['DeleteRecording'](arg1);
+}
+
 export function DeleteScreenshot(arg1) {
   return window['go']['main']['App']['DeleteScreenshot'](arg1);
 }


### PR DESCRIPTION
## What changed

I have add and Implement delete button for recording studio

## Why it changed

User will be easy to delete a videos without using external programs

## How it was tested

run `wails dev`

## Screenshots

<img width="1920" height="1044" alt="Screenshot From 2026-08-23 15-03-48" src="https://github.com/user-attachments/assets/49639acf-33a1-4c83-95da-881fbcad0eef" />


## Notes

Nothing

---

## Checklist

- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [x] Screenshots added for UI changes
