### PR TITLE
refactor: refactor the record list

### DIFF
--- a/app.go
+++ b/app.go
@@ -578,6 +578,11 @@ func (a *App) DeleteRecording(fileName string) error {
 		return err
 	}
 
+	thumbPath := filepath.Join(dir, screencast.ThumbnailFileName(fileName))
+	if _, err := os.Stat(thumbPath); err == nil {
+		os.Remove(thumbPath)
+	}
+
 	s := settings.Load()
 	favs := s.Favorites.Recordings
 	var kept []string
@@ -594,8 +599,9 @@ func (a *App) DeleteRecording(fileName string) error {
 }
 
 type RecordingInfo struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	ThumbnailName string `json:"thumbnailName"`
 }
 
 func (a *App) ListRecordings() ([]RecordingInfo, error) {
@@ -618,9 +624,11 @@ func (a *App) ListRecordings() ([]RecordingInfo, error) {
 			continue
 		}
 		full := filepath.Join(dir, entry.Name())
+		thumbName, _ := screencast.EnsureThumbnail(full)
 		files = append(files, RecordingInfo{
-			Name: entry.Name(),
-			Path: full,
+			Name:          entry.Name(),
+			Path:          full,
+			ThumbnailName: thumbName,
 		})
 	}
 	if files == nil {

--- a/frontend/src/components/Record.tsx
+++ b/frontend/src/components/Record.tsx
@@ -350,6 +350,17 @@ export default function Record({
                   onOpen={() => handleSelectRecording(rec)}
                   onToggleFavorite={() => toggleFavorite(rec.name)}
                   onDelete={() => handleDelete(rec.name)}
+                  thumbnail={
+                    rec.thumbnailName ? (
+                      <img
+                        onClick={() => handleSelectRecording(rec)}
+                        src={`${baseUrl}/${encodeURIComponent(rec.thumbnailName)}`}
+                        alt={rec.name}
+                        className="w-full h-48 object-cover"
+                        loading="lazy"
+                      />
+                    ) : undefined
+                  }
                 />
               ))}
             </div>

--- a/frontend/src/components/Record.tsx
+++ b/frontend/src/components/Record.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { ArrowLeft, RefreshCw, Film, Search, Star, X } from "lucide-react";
+import { ArrowLeft, RefreshCw, Film, Search, Star } from "lucide-react";
 import { RecordProps, Recording } from "@/types/types";
 import {
   ListRecordings,
@@ -10,6 +10,7 @@ import {
 } from "../../wailsjs/go/main/App";
 import { settings } from "../../wailsjs/go/models";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { MediaCard } from "@/components/ui/media-card";
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -235,9 +236,7 @@ export default function Record({
           <h1 className="text-sm font-semibold text-white/90">
             GlowSnap Studio
           </h1>
-        </div>
-
-        <div className="flex bg-white/5 rounded-lg p-0.5 border border-white/10 ml-auto mr-auto">
+          <div className="flex bg-white/5 rounded-lg p-0.5 border border-white/10 ml-auto mr-auto">
           <button
             onClick={onSwitchToStudio}
             className="px-3 py-1 text-xs rounded-md text-white/60 hover:text-white/90 transition-colors"
@@ -248,7 +247,8 @@ export default function Record({
             Record
           </button>
         </div>
-
+        </div>
+        
         <div className="flex items-center gap-3 ml-auto">
           <div className="relative">
             <Search
@@ -340,50 +340,17 @@ export default function Record({
             <span className="text-xs text-white/40 uppercase tracking-wider px-1">
               Recordings
             </span>
-            <div className="flex flex-col gap-0.5">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 auto-rows-max">
               {processedRecordings.map((rec) => (
-                <div
+                <MediaCard
                   key={rec.name}
-                  onClick={() => handleSelectRecording(rec)}
-                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-xs transition-colors text-white/60 hover:bg-white/5 hover:text-white/90 cursor-pointer group"
-                >
-                  <div className="min-w-0">
-                    <span className="block truncate">{rec.name}</span>
-                    {formatDate(rec.name) && (
-                      <span className="text-[10px] text-white/30">
-                        {formatDate(rec.name)}
-                      </span>
-                    )}
-                  </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleFavorite(rec.name);
-                    }}
-                    className={`text-xs shrink-0 ${
-                      favorites.has(rec.name)
-                        ? "text-yellow-400"
-                        : "text-white/30 hover:text-yellow-400"
-                    }`}
-                    title={
-                      favorites.has(rec.name)
-                        ? "Remove from favorites"
-                        : "Add to favorites"
-                    }
-                  >
-                    <Star size={15} />
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleDelete(rec.name);
-                    }}
-                    className="text-xs shrink-0 text-red-400 hover:text-red-300"
-                    title="Delete recording"
-                  >
-                    <X size={15} />
-                  </button>
-                </div>
+                  name={rec.name}
+                  dateLabel={formatDate(rec.name)}
+                  isFavorite={favorites.has(rec.name)}
+                  onOpen={() => handleSelectRecording(rec)}
+                  onToggleFavorite={() => toggleFavorite(rec.name)}
+                  onDelete={() => handleDelete(rec.name)}
+                />
               ))}
             </div>
           </div>

--- a/frontend/src/components/Studio.tsx
+++ b/frontend/src/components/Studio.tsx
@@ -9,7 +9,6 @@ import {
   ArrowLeft,
   Image as ImageIcon,
   RefreshCw,
-  X,
   Search,
   Star,
 } from "lucide-react";
@@ -25,6 +24,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import Editor from "@/components/editor/Editor";
 import { CustomFontsProvider } from "@/lib/customFonts";
 import { Button } from "./ui/button";
+import { MediaCard } from "./ui/media-card";
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -360,9 +360,7 @@ export default function Studio({
           <h1 className="text-sm font-semibold text-white/90">
             GlowSnap Studio
           </h1>
-        </div>
-
-        <div className="flex bg-white/5 rounded-lg p-0.5 border border-white/10 ml-auto mr-auto">
+          <div className="flex bg-white/5 rounded-lg p-0.5 border border-white/10 ml-auto mr-auto">
           <button className="px-3 py-1 text-xs rounded-md bg-white/15 text-white font-medium">
             Studio
           </button>
@@ -372,6 +370,7 @@ export default function Studio({
           >
             Record
           </button>
+        </div>
         </div>
 
         <div className="flex items-center gap-3 ml-auto">
@@ -459,79 +458,36 @@ export default function Studio({
           <>
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 auto-rows-max">
               {currentPageImages.map((file) => (
-                <div
+                <MediaCard
                   key={file.name}
-                  ref={(el) => {
+                  name={file.name}
+                  dateLabel={formatDate(file.date)}
+                  sizeLabel={formatSize(file.size)}
+                  isFavorite={favorites.has(file.name)}
+                  onToggleFavorite={() => toggleFavorite(file.name)}
+                  onDelete={() => handleDelete(file.name)}
+                  cardRef={(el) => {
                     imageRefs.current[file.name] = el;
                   }}
-                  className="relative group bg-white/5 rounded-xl overflow-hidden border border-white/5 hover:border-white/20 transition-all duration-200 cursor-pointer"
-                >
-                  <img
-                    onClick={() => handleImageClick(file)}
-                    src={`${baseUrl}/${encodeURIComponent(file.name)}`}
-                    alt={file.name}
-                    className="w-full h-48 object-cover"
-                    loading="lazy"
-                  />
-                  <div className="p-2 text-xs text-white/70">
-                    {renamingImage === file.name ? (
-                      <input
-                        autoFocus
-                        value={renameValue}
-                        onChange={(e) => setRenameValue(e.target.value)}
-                        onBlur={() => handleRename(file.name, renameValue)}
-                        onKeyDown={(e) =>
-                          e.key === "Enter" &&
-                          handleRename(file.name, renameValue)
-                        }
-                        className="bg-white/10 rounded text-xs px-1 w-full outline-none mb-1"
-                      />
-                    ) : (
-                      <span
-                        onDoubleClick={() => {
-                          renamingRef.current = false;
-                          setRenamingImage(file.name);
-                          setRenameValue(file.name);
-                        }}
-                        className="cursor-pointer block truncate"
-                        title={file.name}
-                      >
-                        {file.name}
-                      </span>
-                    )}
-                    <div className="flex items-center justify-between mt-1">
-                      <span
-                        className="text-[10px] text-white/40 truncate"
-                        title={formatDate(file.date)}
-                      >
-                        {formatDate(file.date)}
-                      </span>
-                      <div className="flex gap-1 shrink-0">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            toggleFavorite(file.name);
-                          }}
-                          className={`text-xs ${favorites.has(file.name) ? "text-yellow-400" : "text-white/30 hover:text-yellow-400"}`}
-                        >
-                          <Star size={15} />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDelete(file.name);
-                          }}
-                          className="text-xs text-red-400 hover:text-red-300"
-                        >
-                          <X size={15} />
-                        </button>
-                      </div>
-                    </div>
-                    <span className="text-[10px] text-white/30">
-                      {formatSize(file.size)}
-                    </span>
-                  </div>
-                </div>
+                  thumbnail={
+                    <img
+                      onClick={() => handleImageClick(file)}
+                      src={`${baseUrl}/${encodeURIComponent(file.name)}`}
+                      alt={file.name}
+                      className="w-full h-48 object-cover"
+                      loading="lazy"
+                    />
+                  }
+                  renaming={renamingImage === file.name}
+                  renameValue={renameValue}
+                  onRenameChange={setRenameValue}
+                  onRenameCommit={() => handleRename(file.name, renameValue)}
+                  onStartRename={() => {
+                    renamingRef.current = false;
+                    setRenamingImage(file.name);
+                    setRenameValue(file.name);
+                  }}
+                />
               ))}
             </div>
             {page < totalPages && (

--- a/frontend/src/components/ui/media-card.tsx
+++ b/frontend/src/components/ui/media-card.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Film, Star, X } from "lucide-react";
+
+interface MediaCardProps {
+  name: string;
+  dateLabel?: string;
+  sizeLabel?: string;
+  isFavorite: boolean;
+  onToggleFavorite: () => void;
+  onDelete: () => void;
+  onOpen?: () => void;
+  thumbnail?: React.ReactNode;
+  cardRef?: (node: HTMLDivElement | null) => void;
+  renaming?: boolean;
+  renameValue?: string;
+  onRenameChange?: (value: string) => void;
+  onRenameCommit?: () => void;
+  onStartRename?: () => void;
+}
+
+export function MediaCard({
+  name,
+  dateLabel,
+  sizeLabel,
+  isFavorite,
+  onToggleFavorite,
+  onDelete,
+  onOpen,
+  thumbnail,
+  cardRef,
+  renaming = false,
+  renameValue = "",
+  onRenameChange,
+  onRenameCommit,
+  onStartRename,
+}: MediaCardProps) {
+  return (
+    <div
+      ref={cardRef}
+      className="relative group bg-white/5 rounded-sm overflow-hidden border border-white/5 hover:border-white/20 transition-all duration-200 cursor-pointer"
+    >
+      {thumbnail ?? (
+        <button
+          type="button"
+          onClick={onOpen}
+          title={name}
+          className="w-full h-48 flex items-center justify-center bg-white/5 hover:bg-white/10 transition-colors"
+        >
+          <Film size={40} className="stroke-1 text-white/30" />
+        </button>
+      )}
+
+      <div className="p-2 text-xs text-white/70">
+        {renaming ? (
+          <input
+            autoFocus
+            value={renameValue}
+            onChange={(e) => onRenameChange?.(e.target.value)}
+            onBlur={onRenameCommit}
+            onKeyDown={(e) => e.key === "Enter" && onRenameCommit?.()}
+            className="bg-white/10 rounded text-xs px-1 w-full outline-none mb-1"
+          />
+        ) : (
+          <span
+            onDoubleClick={onStartRename}
+            className="cursor-pointer block truncate"
+            title={name}
+          >
+            {name}
+          </span>
+        )}
+
+        <div className="flex items-center justify-between mt-1">
+          {dateLabel && (
+            <span
+              className="text-[10px] text-white/40 truncate"
+              title={dateLabel}
+            >
+              {dateLabel}
+            </span>
+          )}
+          <div className="flex gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleFavorite();
+              }}
+              className={`text-xs ${
+                isFavorite ? "text-yellow-400" : "text-white/30 hover:text-yellow-400"
+              }`}
+              title={isFavorite ? "Remove from favorites" : "Add to favorites"}
+            >
+              <Star size={15} />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="text-xs text-red-400 hover:text-red-300"
+              title="Delete"
+            >
+              <X size={15} />
+            </button>
+          </div>
+        </div>
+
+        {sizeLabel && (
+          <span className="text-[10px] text-white/30">{sizeLabel}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -3,6 +3,7 @@ export namespace main {
 	export class RecordingInfo {
 	    name: string;
 	    path: string;
+	    thumbnailName: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new RecordingInfo(source);
@@ -12,6 +13,7 @@ export namespace main {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
 	        this.path = source["path"];
+	        this.thumbnailName = source["thumbnailName"];
 	    }
 	}
 	export class ScreenshotInfo {

--- a/services/screencast/thumbnail.go
+++ b/services/screencast/thumbnail.go
@@ -1,0 +1,65 @@
+package screencast
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const ffmpegBinary = "ffmpeg"
+
+func ThumbnailFileName(videoName string) string {
+	base := videoName
+	if dot := strings.LastIndex(base, "."); dot >= 0 {
+		base = base[:dot]
+	}
+	return base + ".jpg"
+}
+
+func EnsureThumbnail(videoPath string) (string, error) {
+	dir := filepath.Dir(videoPath)
+	name := ThumbnailFileName(filepath.Base(videoPath))
+	thumbPath := filepath.Join(dir, name)
+	if _, err := os.Stat(thumbPath); err == nil {
+		return name, nil
+	}
+	if _, err := exec.LookPath(ffmpegBinary); err != nil {
+		return "", nil
+	}
+
+	if err := runThumbnail(videoPath, thumbPath, 1); err != nil {
+		os.Remove(thumbPath)
+		if retryErr := runThumbnail(videoPath, thumbPath, 0); retryErr != nil {
+			os.Remove(thumbPath)
+			return "", retryErr
+		}
+	}
+	if _, err := os.Stat(thumbPath); err != nil {
+		return "", fmt.Errorf("ffmpeg produced no thumbnail for %s", videoPath)
+	}
+	return name, nil
+}
+
+func runThumbnail(videoPath, thumbPath string, seekSeconds int) error {
+	args := []string{
+		"-y",
+		"-ss", fmt.Sprintf("%d", seekSeconds),
+		"-i", videoPath,
+		"-frames:v", "1",
+		"-vf", "scale=480:-1",
+		"-q:v", "5",
+		thumbPath,
+	}
+
+	cmd := exec.Command(ffmpegBinary, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## What changed

Change the record list UI to a cards 

## Why it changed

So that there is consistency in the design between the studio for photos and for the record

## How it was tested

run `wails dev` and test it.

## Screenshots

**Old:**
<img width="1920" height="1044" alt="Screenshot From 2026-08-23 15-03-48" src="https://github.com/user-attachments/assets/a21189e9-585d-4b70-87cf-750068e84329" />


**New:**
<img width="1920" height="1044" alt="Screenshot From 2026-08-23 15-54-25" src="https://github.com/user-attachments/assets/f3383a9b-9175-404c-a72e-a35b39670e29" />


## Notes

> Note: the loading for thumbnail is a bit slow due to the fact that it is beta 

---

## Checklist

- [x] Tests pass (or no tests are affected)
- [ ] Documentation updated if needed
- [x] Code is formatted and lint-clean
- [x] No unnecessary dependencies added
- [x] Breaking changes (if any) are called out in the Notes
- [x] Screenshots added for UI changes
